### PR TITLE
Fix conflict with moui.css in button:hover

### DIFF
--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -45,6 +45,7 @@
     position: absolute;
     top: 22px;
     right: 22px;
+    left: auto;
     z-index: 900;
     @include respond((
       display: block null none,


### PR DESCRIPTION
Moui.css specifies `top: 1px; left: 1px` for button:hover, so this change is necessary so the new absolutely positioned nav close button (mobile) doesn't move all the way to the left side of the screen.