### PR TITLE
Change deploy bucket to static.moveon.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_deploy:
   - cp -r public/styles deploy/
 deploy:
   on:
-    branch: 8-cors-headers
+    branch: main
   provider: s3
   access_key_id: AKIAITZUUGIJNKLB4PHA
   bucket: static.moveon.org


### PR DESCRIPTION
Addresses #8 . Travis s3 autodeploy allows AWS S3 header setting only at the bucket level. There is a per-resource option to set headers via aws-cli but it's not in travis yet. s3.moveon.org has a lot of stuff in it and some actionkit-specific headers.