### PR TITLE
Add option to use wrapper for nav padding

### DIFF
--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -42,7 +42,8 @@
   }
 }
 
-body {
+// You can use either a '.giraffe>body' or a .giraffe#wrapper to add padding for the nav
+body, &#wrapper {
   @include respond((
     padding-top: 57px null 120px,
   ));


### PR DESCRIPTION
Fixes https://github.com/MoveOnOrg/giraffe/issues/2

This is nice to have because in react apps we rarely have easy control over `<html>`