### PR TITLE
Change font path to be direct in production

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-ENV=production
+ENV=development

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - 7.10.1
 before_script:
 - npm install -g gulp-cli
+- export ENV=production
 script: gulp
 before_deploy:
   - cp -r public/fonts deploy/

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -8,6 +8,7 @@ let combineMq = require('gulp-combine-mq');
 let autoprefixer = require('gulp-autoprefixer');
 let cleanCSS = require('gulp-clean-css');
 let notifier = require('node-notifier');
+var preprocess = require('gulp-preprocess');
 
 let isDev = isLocal || isDevelopment ? true : false;
 let src = projectRoot('src/styles/main.scss');
@@ -20,6 +21,15 @@ module.exports = {
             .pipe(onStreamError('Styles Task Failed!'))
             .pipe(gulpif( isDev, sourcemaps.init() ))
             .pipe(sass().on('error', sass.logError))
+            .pipe(
+              preprocess({
+                context: {
+                  FONT_PATH: isProduction
+                    ? 'https://s3.us-east-2.amazonaws.com/static.moveon.org/giraffe/'
+                    : '/'
+                }
+              })
+            )
               .pipe( gulpif( isProduction, combineMq()) )
               .pipe( gulpif( isProduction, autoprefixer()) )
               .pipe( gulpif( isProduction, cleanCSS()) )

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp": "^3.9.1",
     "gulp-font": "^1.0.4",
     "gulp-imagemin": "^4.1.0",
+    "gulp-preprocess": "^2.0.0",
     "gulp-svg-sprite": "^1.3.7",
     "gulp-tasks-preset": "^0.3.4",
     "gulp-twig": "^1.1.1",

--- a/src/styles/settings/_typography.scss
+++ b/src/styles/settings/_typography.scss
@@ -1,27 +1,27 @@
 @font-face {
   font-family: 'Roboto Condensed';
-  src: url('/fonts/RobotoCondensed-Regular.ttf');
+  src: url('/* @echo FONT_PATH */fonts/RobotoCondensed-Regular.ttf');
 }
 
 @font-face {
   font-family: 'Roboto Condensed Bold';
-  src: url('/fonts/RobotoCondensed-Bold.ttf');
+  src: url('/* @echo FONT_PATH */fonts/RobotoCondensed-Bold.ttf');
   font-weight: bolder;
 }
 
 @font-face {
   font-family: 'Roboto Regular';
-  src: url('/fonts/Roboto-Regular.ttf');
+  src: url('/* @echo FONT_PATH */fonts/Roboto-Regular.ttf');
 }
 
 @font-face {
   font-family: 'Roboto Medium';
-  src: url('/fonts/Roboto-Medium.ttf');
+  src: url('/* @echo FONT_PATH */fonts/Roboto-Medium.ttf');
 }
 
 @font-face {
   font-family: 'Roboto Bold';
-  src: url('/fonts/Roboto-Bold.ttf');
+  src: url('/* @echo FONT_PATH */fonts/Roboto-Bold.ttf');
 }
 
 


### PR DESCRIPTION
I'm not sure if this is actually a good way to do this. There's probably a better way, so I'm up for suggestions.

But it seems likely that fonts will need to be in a subdir in production, so this is one way of fixing that.

E.g. I was getting this error
```
Failed to decode downloaded font: http://s3.us-east-2.amazonaws.com/fonts/RobotoCondensed-Bold.ttf
```