### PR TITLE
Fix nav link hover

### DIFF
--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -95,11 +95,14 @@
       @include respond((
         color: $black null $white,
       ));
+      &:hover {
+        color: $azure;
+      }
     }
 
     &:hover,
     &:active {
-      color: $azure !important;
+      color: $azure;
 
       svg {
         fill: $azure;


### PR DESCRIPTION
Somehow the hover is working on http://moveon-dev.netlify.com, but it isn't working on localhost, it's being overridden with the white from :visited... This is a simple fix that doesn't seem too harmful.