### PR TITLE
Option to override input-box:first-of-type collapse, plus fix some conflicts with moui.css

### DIFF
--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -9,7 +9,7 @@ form {
       line-height: 20px,
     ));
 
-    &:not(:first-of-type) {
+    &:not(:first-of-type), &.override-collapse {
       @include respond((
         margin-top: 30px,
       ));
@@ -80,7 +80,9 @@ form {
       left: 0;
       transition: all .3s;
       transform-origin: top left;
+      font-weight: normal;
       @include respond((
+        font-size: 14px null 16px,
         display: flex,
         align-items: center,
         height: 100%,


### PR DESCRIPTION
If an input box is the first child, it normally doesn't have padding. This messes things up if I want to have to have a container-div in the middle of the form.

With this PR, you can add `.override-collapse` to an `.input-box` in a container-div and it will have the needed top margin.

The `font-weight` and `font-size` are things that should have been applied to labels, but moui.css has more specificity.