### PR TITLE
Also deploy to mop-static-stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
 
   - provider: s3
     on:
-      branch: stage-deploy
+      branch: main
     access_key_id: AKIAITZUUGIJNKLB4PHA
     bucket: mop-static-stage
     skip_cleanup: true


### PR DESCRIPTION
I just copied the secret access key from above. It looks like the access_key_id is the same in mop-frontend, so it might work. Otherwise someone should regenerate it.

This should deploy the changes both to static.moveon.org and mop-static-stage, so broom can read them.