### PR TITLE
Set body margin to 0 outside of .giraffe

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -14,6 +14,7 @@
 @include define-breakpoints($breakpoints);
 
 body {
+  // All styles here must be compatible with moui.css
   margin: 0;
 }
 


### PR DESCRIPTION
We will need this reset outside of `.giraffe` when we are not setting giraffe on `<html>` and we don't have moui.css (which also has this style), such as rebranded petitions.