### PR TITLE
disable donate scripts in app.js

### DIFF
--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -6,6 +6,7 @@ let uglify = require('rollup-plugin-uglify');
 let notifier = require('node-notifier');
 
 let output = projectRoot('public/scripts/app.js');
+let donateOutput = projectRoot('public/scripts/donate.js');
 let isDev = isDevelopment || isLocal ? true : false;
 let isProd = isStaging || isProduction ? true : false;
 
@@ -19,12 +20,21 @@ module.exports = {
 
     try {
 
-      const bundle = await rollup.rollup(rollupConfig);
+      const bundle = await rollup.rollup(rollupConfig({ isDonate: false }));
 
       await bundle.write({
         file: output,
         format: 'iife',
         name: 'app_scripts',
+        sourcemap: isDev ? true : false,
+      });
+
+      const donateBundle = await rollup.rollup(rollupConfig({ isDonate: true }));
+
+      await donateBundle.write({
+        file: donateOutput,
+        format: 'iife',
+        name: 'donate_scripts',
         sourcemap: isDev ? true : false,
       });
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,13 +9,14 @@ let uglify = require('rollup-plugin-uglify');
 let isDev = isDevelopment || isLocal ? true : false;
 let isProd = isStaging || isProduction ? true : false;
 let entry = projectRoot('src/scripts/app.js');
+let donateEntry = projectRoot('src/scripts/donate.js');
 let rollupPlugins = isProd ? [ uglify() ] : [];
 rollupPlugins = rollupPlugins.concat([
   babel(),
   node(),
 ]);
 
-module.exports = {
-  input: entry,
+module.exports = ({ isDonate }) => ({
+  input: isDonate ? donateEntry : entry,
   plugins: rollupPlugins,
-}
+})

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -8,12 +8,6 @@ import HomeHero from './components/homeHero';
 import SignForm from './components/signForm';
 import PetitionComments from './components/petitionComments';
 import PetitionCard from './components/petitionCard';
-import DonateReceipt from './components/donateReceipt';
-import DonateShortForm from './components/donateShortForm';
-import DonateFullForm from './components/donateFullForm';
-import DonateQuickPay from './components/donateQuickPay';
-import DonateBoxedForm from './components/donateBoxedForm';
-import PriceSelectGroup from './components/priceSelectGroup';
 
 $(document).ready(function () {
   Nav.init();
@@ -26,13 +20,4 @@ $(document).ready(function () {
   SignForm.init();
   PetitionComments.init();
   PetitionCard.init();
-  /* NOTE: the donate page logic now lives in:
-    ak-template-set/template_components/donate/scripts.html
-
-    DonateReceipt.init();
-    DonateShortForm.init();
-    DonateFullForm.init();
-    DonateBoxedForm.init();
-    DonateQuickPay.init();
-    PriceSelectGroup.init(); */
 });

--- a/src/scripts/donate.js
+++ b/src/scripts/donate.js
@@ -1,0 +1,19 @@
+import DonateReceipt from './components/donateReceipt';
+import DonateShortForm from './components/donateShortForm';
+import DonateFullForm from './components/donateFullForm';
+import DonateQuickPay from './components/donateQuickPay';
+import DonateBoxedForm from './components/donateBoxedForm';
+import PriceSelectGroup from './components/priceSelectGroup';
+
+$(document).ready(function () {
+  /* NOTE: the donate page logic now lives in:
+    ak-template-set/template_components/donate/scripts.html
+    so this is parsed out specifically for the demo pages */
+
+    DonateReceipt.init();
+    DonateShortForm.init();
+    DonateFullForm.init();
+    DonateBoxedForm.init();
+    DonateQuickPay.init();
+    PriceSelectGroup.init();
+});

--- a/src/templates/layout.twig
+++ b/src/templates/layout.twig
@@ -17,5 +17,6 @@
         </div>
         <script src="scripts/vendors.js"></script>
         <script src="scripts/app.js"></script>
+        <script src="scripts/donate.js"></script>
     </body>
 </html>


### PR DESCRIPTION
I've moved the donate page JS logic into https://github.com/MoveOnOrg/ak-template-set/blob/main-giraffe/template_components/partials/donate/scripts.html so these are no longer needed.

The compiled app.js is currently loaded into the AK template wrapper and affects some functionality -- really this just needs the nav and maybe generic form logic extracted and added to ak-js, but having the donate scripts immediately disabled will unblock QA work.