### PR TITLE
Flexible, even-width donation v3 radios w/ dynamic content

### DIFF
--- a/src/styles/mo-components/_fixes.scss
+++ b/src/styles/mo-components/_fixes.scss
@@ -84,3 +84,38 @@ body.donate-page {
     }
   }
 }
+
+// donate-page v3 radios
+.giraffe {
+  .donate-v3 {
+    .donate-form {
+      .price-select {
+        max-width: 300px;
+
+        .radio-input {
+          width: 30%;
+          min-width: 90px;
+
+          &:nth-child(2),
+          &:nth-child(3),
+          &:nth-child(5),
+          &:nth-child(6) {
+            @include respond((
+              margin-left: 0 0 0,
+            ));
+          }
+        }
+
+        .radio-input-other {
+          @include respond((
+            margin-left: 0 0 0,
+          ));
+
+          @media screen and (max-width: $bp-lg) {
+            width: 157px;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
See: https://github.com/MoveOnOrg/ak-template-set/issues/435

Had to actually wrap this in all these selectors for the override to take effect.

Now looks like:
![screen shot 2018-03-16 at 8 57 43 am](https://user-images.githubusercontent.com/13374656/37521772-3d7aea7a-28f8-11e8-803b-490f9ee5dd30.png)
![screen shot 2018-03-16 at 8 57 59 am](https://user-images.githubusercontent.com/13374656/37521775-3f049968-28f8-11e8-9030-d37e4eb0e1a6.png)
![screen shot 2018-03-16 at 9 02 54 am](https://user-images.githubusercontent.com/13374656/37521963-d6b42210-28f8-11e8-84d5-aa5b7b9f5d82.png)

