### PR TITLE
Rework home-hero component to observe user-set background colors

### DIFF
--- a/src/scripts/components/homeHero.js
+++ b/src/scripts/components/homeHero.js
@@ -11,13 +11,22 @@ class HomeHero {
 
   bindCarousels() {
     let _this = this;
+    this.$contentCarousel.on('ready.flickity', function() {
+        if (_this.$contentCarousel.find('.home-hero__text').first().hasClass('home-hero-bg-red')) {
+
+            _this.$contentCarousel.parent().addClass('home-hero-bg-red');
+        }
+    });
     this.$contentCarousel.flickity({
       adaptiveHeight: true,
       wrapAround: true,
     })
     .on('select.flickity', function () {
       let _flickityData = _this.$contentCarousel.data('flickity');
-      _this.$contentCarousel.parent().toggleClass('even', (_flickityData.selectedIndex + 1) % 2 == 0);
+      _this.$contentCarousel.parent().removeClass('home-hero-bg-red');
+       if ($(_flickityData.selectedElement).hasClass('home-hero-bg-red')) {
+           _this.$contentCarousel.parent().addClass('home-hero-bg-red');
+        }
     });
     this.$imageCarousel.flickity({
       sync: this.$contentCarousel[0],

--- a/src/styles/components/_home-hero.scss
+++ b/src/styles/components/_home-hero.scss
@@ -193,11 +193,6 @@
       opacity: 0;
     }
 
-    &:nth-child(even) {
-      .home-hero__heading span {
-        color: $red;
-      }
-    }
   }
 
 
@@ -258,13 +253,6 @@
         padding: (6px 8px) null,
       ));
     }
-  }
-
-
-
-  // EVEN-CHILD STATE
-  .home-hero__content.even {
-    background-color: $red;
   }
 
 


### PR DESCRIPTION
For issue #99 . Had to modify both scripts and styles in the component to pull out the hard-wired even/odd background alternation. 

Couple of notes:

1) Since we only have two colors we need to support, I left azure as the default background color and just overrode that in cases where the user specified red. This simplified the immediate problem, but could come back to bite us later if we need to add additional colors -- let me know if you think that's worth worrying about.

2) Right now I have the slides getting set with the classes `home-hero-bg-blue` and `home-hero-bg-red` to indicate which color the user set for them. I picked these class names more or less out of thin air, so if there's some better way to name them (i.e. using some semantic naming rather than calling out specific colors), let me know.

3) I feel like there is probably a more elegant way to express what I'm trying to do in the JavaScript part of this than the one that I used. JS isn't my primary language, though, so I don't really speak it like a native. If it needs rewriting to make it more idiomatic, feel free to point me in the right direction.