### PR TITLE
Move logic to get header text color right from theme to component

### DIFF
--- a/src/styles/components/_home-hero.scss
+++ b/src/styles/components/_home-hero.scss
@@ -109,6 +109,22 @@
       padding: (24px 16px) null (0 percentage(230px/1440px) 0 percentage(55px/1440px)),
     ));
 
+    &.home-hero-bg-red {
+
+        background-color: $red;
+
+        .home-hero__heading {
+
+            span {
+
+                color: $red;
+
+            }
+
+        }
+
+    }
+
     &__carousel {
       position: relative;
       width: 100%;


### PR DESCRIPTION
I had accidentally left the logic that sets the header text color (as opposed to background color) for `home-hero-bg-red` elements in the theme, rather than moving it into the component. This led to a weird straddle situation where the component only had half the styling it needed to actually style those elements. This moves that logic into the component so it's all in one place.