### PR TITLE
Disables page dot navigation if only one slide

### DIFF
--- a/src/scripts/components/homeHero.js
+++ b/src/scripts/components/homeHero.js
@@ -17,9 +17,19 @@ class HomeHero {
             _this.$contentCarousel.parent().addClass('home-hero-bg-red');
         }
     });
+
+    let showCarouselChrome = true;
+
+    if (this.$contentCarousel.find('.home-hero__text').length < 2) {
+
+        showCarouselChrome = false;
+
+    }
+    
     this.$contentCarousel.flickity({
       adaptiveHeight: true,
       wrapAround: true,
+        pageDots: showCarouselChrome
     })
     .on('select.flickity', function () {
       let _flickityData = _this.$contentCarousel.data('flickity');


### PR DESCRIPTION
Closes #108. (Or at least it's as close as we can get, I think -- it only suppresses the navigation dots, not the arrows, but that's because [it looks like Flickity doesn't really let you suppress the arrows without hacking it](https://github.com/metafizzy/flickity/issues/289).)