### PR TITLE
fixes vertical spacing in cta grid on homepage

### DIFF
--- a/src/styles/mo-components/_fixes.scss
+++ b/src/styles/mo-components/_fixes.scss
@@ -23,6 +23,10 @@ h3.home_illustration__content-heading {
   ));
 }
 
+p.cta-grid__text {
+  margin-bottom: 0;
+}
+
 /* Fixes form input vertical alignment after substituting
 static labels for animated labels https://github.com/MoveOnOrg/giraffe/issues/88
 */


### PR DESCRIPTION
Supposed to look like this:
<img width="1190" alt="move_on" src="https://user-images.githubusercontent.com/5560919/37794734-020c762c-2dd8-11e8-8e39-b2472d2a9eaa.png">

Add the default leading of 1em after <p> inserted a bunch of vertical space in between cta links.
