### PR TITLE
Make 'Effecting Real Change' slide captions wrap to multiple lines

### DIFF
--- a/src/styles/components/_home-carousel.scss
+++ b/src/styles/components/_home-carousel.scss
@@ -143,6 +143,9 @@
     margin-bottom: auto;
     top: -30px !important;
     line-height: 1;
+    white-space: pre-line;
+    text-align: center;
+    padding: 10px;
     @include respond((
       font-size: (20px !important) null (28px !important),
     ));


### PR DESCRIPTION
Fixes #124. (I also added a little padding to the left and right, to keep the caption from running right up against the sides of the slide.)

Once this is merged into Giraffe I'll update the theme to output the full post title as the caption, rather than trimming it down to 3 words.