### PR TITLE
Move reusable petition-card styles to mo-components card

### DIFF
--- a/src/styles/components/_petition-card.scss
+++ b/src/styles/components/_petition-card.scss
@@ -1,56 +1,4 @@
 .petition-card {
-  background-color: $ice-blue;
-  position: relative;
-  @include respond((
-    padding: (21px 22px 28px) null (107px percentage(80/780) 66px),
-  ));
-
-  &__heading {
-
-    span {
-      display: inline-block;
-      padding: 2px 5px;
-      @include font(roboto-condensed-bold);
-      @include respond((
-        font-size: 21px null 48px,
-        line-height: .9 null 48px,
-        letter-spacing: -.6px null normal,
-        background-color: $azure,
-      ));
-    }
-  }
-
-  &__body {
-    @include respond((
-      margin-top: 13px null 24px,
-    ));
-
-    p {
-      @include respond((
-        font-size: 16px null 18px,
-        line-height: 24px null 24px,
-      ));
-      @include font(roboto);
-
-      &:not(:first-child) {
-        @include respond((
-          margin-top: 20px null 32.5px,
-        ));
-      }
-    }
-
-    strong {
-      @include font(roboto-bold);
-    }
-
-  }
-
-  &__media {
-    @include respond((
-      margin-top: 15px null 29px,
-    ));
-  }
-
   &__description {
     @include respond((
       margin-top: 20px null 32.5px
@@ -223,7 +171,7 @@
     .tooltipped-down::before {
       right: 1px;
     }
-  }
+}
 
 
   // EXPANDED DESCRIPTION STATE

--- a/src/styles/mo-components/_cards.scss
+++ b/src/styles/mo-components/_cards.scss
@@ -1,9 +1,57 @@
 .card {
+  background-color: $ice-blue;
   position: relative;
-  margin: 0 1.3125rem;
-  padding: 8% 10% 12%;
 
-  &__content, &__media {
-    margin-top: 1em;
+  @include respond((
+    padding: (21px 22px 28px) null (107px percentage(80/780) 66px),
+  ));
+
+  &--center {
+    text-align: center;
+  }
+
+  &__heading {
+    span {
+      display: inline-block;
+      padding: 2px 5px;
+      @include font(roboto-condensed-bold);
+      @include respond((
+        font-size: 21px null 48px,
+        line-height: .9 null 48px,
+        letter-spacing: -.6px null normal,
+        background-color: $azure,
+      ));
+    }
+  }
+
+  &__body {
+    @include respond((
+      margin-top: 13px null 24px,
+    ));
+
+    p {
+      @include respond((
+        font-size: 16px null 18px,
+        line-height: 24px null 24px,
+      ));
+      @include font(roboto);
+
+      &:not(:first-child) {
+        @include respond((
+          margin-top: 20px null 32.5px,
+        ));
+      }
+    }
+
+    strong {
+      @include font(roboto-bold);
+    }
+
+  }
+
+  &__media {
+    @include respond((
+      margin-top: 15px null 29px,
+    ));
   }
 }

--- a/src/templates/components/petition-card.twig
+++ b/src/templates/components/petition-card.twig
@@ -1,14 +1,14 @@
-<div class="petition-card col-12">
-  <div class="petition-card__content">
+<div class="card petition-card col-12">
+  <div class="card__content">
 
-    <div class="petition-card__heading">
+    <div class="card__heading">
       {{'WE NEED A REAL SOLUTION FOR THE HEROIN, FENTANYL, OXYCONTIN, AND OPIOID EPIDEMIC NOW' | wrap-words}}
     </div>
 
-    <div class="petition-card__body">
+    <div class="card__body">
       <p>To Eric Hargan, Acting secretary of Health and Human Services and President Donald Trump</p>
 
-      <div class="petition-card__media">
+      <div class="card__media">
         <div class="media">
           <img src="images/petition-card-media.jpg" alt="">
           <button class="mo-btn media__play"></button>


### PR DESCRIPTION
So that we can reuse it on the petition home page.

My thought is that "cards" should have consistent layout, padding, and internal margins, so maybe it's ok to not use bootstrap grid inside of a card, as long as the card can be integrated into a bootstrap layout. This is debatable though, and might change once we want to have more complex cards. Let me know what you think.