### PR TITLE
Error classes and muted-red classes and var examples

### DIFF
--- a/src/styles/mo-components/_errors.scss
+++ b/src/styles/mo-components/_errors.scss
@@ -7,7 +7,34 @@ label.ak-error {
 input.ak-error {
   border-bottom-color: $muted-red !important;
 }
+form {
+  .input-block,
+  .checkbox-input,
+  .radio-input {
+    &.giraffe-has-errors,
+    &.giraffe-has-errors.border {
+      border-color: $muted-red;
+      color: $muted-red;
+      label {
+        color: $muted-red;
+      }
+      input,
+      textarea,
+      select {
+        color: $muted-red;
+        border-color: $muted-red;
+      }
+      select {
+        option,
+        option:focus {
+          color: $muted-red;
+        }
+      }
+    }
+  }
+}
 
+ul.giraffe-errors-list > li,
 ul#ak-errors > li,
 ul.errorlist > li,
 ul.ak-err > li {

--- a/src/styles/mo-utilities/_color-classes.scss
+++ b/src/styles/mo-utilities/_color-classes.scss
@@ -88,3 +88,6 @@
 .red {
   color: $red;
 }
+.muted-red {
+  color: $muted-red;
+}

--- a/src/templates/pages/content-block-examples.twig
+++ b/src/templates/pages/content-block-examples.twig
@@ -91,7 +91,8 @@
                'bg-azure',
                'bg-light-blue',
                'bg-ice-blue',
-               'bg-red'
+               'bg-red',
+               'bg-muted-red '
               ],
               'Font Color Classes' : [
                'white',
@@ -108,7 +109,8 @@
                'azure',
                'light-blue',
                'ice-blue',
-               'red'
+               'red',
+               'muted-red '
               ]
             }
             

--- a/src/templates/pages/styleguide-forms.twig
+++ b/src/templates/pages/styleguide-forms.twig
@@ -94,6 +94,43 @@
                           <label for="test_checkbox_2">Checkboxes without .border and .label-above class</label>
                         </div>
                         
+                        <div class="checkbox-input giraffe-has-errors">
+                          <input type="checkbox" name="test_checkbox_2" id="test_checkbox_2">
+                          <label for="test_checkbox_2">Checkboxes without .border and .label-above class and class giraffe-has-errors</label>
+                        </div>
+                        
+                        <div class="radio-input border label-above giraffe-has-errors">
+                          <label for="test_radio">Radios with .border, .giraffe-has-errors and .label-above class</label>
+                          <input type="radio" name="test_radio" id="test_radio" checked> I'm human
+                        </div>
+                        
+                        <div class="checkbox-input border label-above giraffe-has-errors">
+                          <label for="test_checkbox">Checkboxes with .giraffe-has-errors, .border and .label-above class</label>
+                          <input type="checkbox" name="test_checkbox" id="test_checkbox"> I'm human
+                        </div>
+
+                        <div class="input-block label-before-input giraffe-has-errors">
+                          <label>Label - Text field with .giraffe-has-errors, label-before-input class on the parent</label>
+                          <input type="text" name="some_name" value="" id="some_name">
+                        </div>
+                        
+                        <div class="input-block textarea-input label-before-input giraffe-has-errors">
+                          <label>Label - Textarea with .giraffe-has-errors, textarea-input and label-before-input class on the parent</label>
+                          <textarea></textarea>
+                        </div>
+                        
+                        <div class="input-block label-before-input mt-4 giraffe-has-errors">
+                          <label>Label - Select with empty value option and option text and with .label-before-input and .giraffe-has-errors class on the parent</label>
+                          <select name="select_a" id="id_select_a"><option value="">Select one</option><option value="Y">Yes</option> <option value="N">No</option></select>
+                        </div>
+                        
+                        <div class="buttons">
+                          <button class="btn">Button</button>
+                          <ul class="giraffe-errors-list">
+                            <li>I'm an error'</li>
+                          </ul>
+                        </div>
+                        
                       </form>
                       
                       

--- a/src/templates/pages/styleguide.twig
+++ b/src/templates/pages/styleguide.twig
@@ -25,6 +25,7 @@
                 <ul>
                    <li><a href="styleguide-forms.html">Form Elements</a>
                    <li><a href="styleguide-grid.html">Grid</a>
+                   <li><a href="content-block-examples.html">Content block examples</a>
                 </ul>
                 {% endblock %}
             {% endembed %}
@@ -48,7 +49,8 @@
                             ['#00abff', '$azure'],
                             ['#99ddff', '$light-blue'],
                             ['#e5f5ff', '$ice-blue'],
-                            ['#ea1c24', '$red']
+                            ['#ea1c24', '$red'],
+                            ['#c3645c', '$muted-red']
                         ] %}
                         <tbody>
                             <tr>


### PR DESCRIPTION
New error classes, and examples
Added link to content-block-examples
Added muted-red to the styleguide and content-block-examples