### PR TITLE
Add gulp task proxy-mop-frontend

### DIFF
--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -41,7 +41,7 @@ module.exports = {
 function onStylesDone() {
   notifier.notify({ title: 'Gulp', message: 'Styles Task Finished!' });
   // Manually inject css to ensure compiled css will reflect
-  if ( isWatching && browserSync.initialized ) {
+  if ( browserSync.initialized ) {
     gulp.src(`${dest}/main.css`)
       .pipe(browserSync.stream());
   }

--- a/gulp/watch-proxy.js
+++ b/gulp/watch-proxy.js
@@ -1,0 +1,19 @@
+let { browserSync } = require('gulp-tasks-preset');
+let gulp = require('gulp');
+let watch = require('gulp-watch');
+
+gulp.task('proxy-mop-frontend', ['styles'], function () {
+  browserSync.init({
+    proxy: 'localhost:8080',
+    // To use these styles in mop-frontend, use `THEME=giraffe LOCAL_CSS=/styles/main.css npm run dev`
+    serveStatic: [{
+        route: '/styles',
+        dir: 'public/styles'
+    }, {
+      route: '/fonts',
+      dir: 'public/fonts'
+  }]
+  }, () => { browserSync.initialized = true; });
+
+  gulp.watch("src/styles/**/*.scss", ['styles']);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,3 +49,8 @@ tasks = isLocal || isDevelopment ? devOnlyTasks.concat(tasks) : tasks;
 tasks = isStaging || isProduction ? prodOnlyTasks.concat(tasks) : tasks;
 
 registerTasks(tasks);
+
+/**
+ * A watch task that proxies another local server
+ */
+require('./gulp/watch-proxy');


### PR DESCRIPTION
A better way of developing styles in mop frontend! Has live css reload!
See this for how to use https://github.com/MoveOnOrg/mop-frontend/blob/392c048dc41e5a321928f0acdd5ddb89d27552e2/docs/HOWTO--giraffe.md