### PR TITLE
social share link styles

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -57,6 +57,7 @@ body {
   @import 'mo-components/errors';
   @import 'mo-components/blurb';
   @import 'mo-components/searchbar';
+  @import 'mo-components/social';
 
   // PER PAGE COMPONENTS
   @import "components/home-hero";

--- a/src/styles/mo-components/_social.scss
+++ b/src/styles/mo-components/_social.scss
@@ -1,0 +1,19 @@
+.share_item, .share_item:active, .share_item:visited {
+  display: inline-flex;
+  font-size: 1rem;
+  line-height: 20px;
+  padding: .5em;
+  margin-right: 2em;
+  color: $azure;
+  svg {
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    margin-right: 1em;
+    fill: $azure;
+  }
+  &.flex {
+    display: flex;
+  }
+}
+

--- a/src/templates/pages/styleguide-social.twig
+++ b/src/templates/pages/styleguide-social.twig
@@ -1,0 +1,62 @@
+
+{% set markup = { blocks: ['markup']} %}
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">                <meta charset="utf-8">
+        <title>{% block title %}Move On Styleguide{% endblock %}</title>
+        <link rel="stylesheet" href="styles/vendors.css" />
+        <link rel="stylesheet" href="styles/main.css" />
+        <link rel="stylesheet" href="styles/styleguide.css" />
+    </head>
+    <body class="giraffe rp {% block bodyclass %}styleguide {% endblock %}">
+        <div style="display:none">{% include 'components/symbol/svg/sprite.symbol.svg' %}</div>
+        <div class="wrapper">
+
+          {% include 'styleguide/header' %}
+
+            {# SOCIAL SHARE LINKS #}
+            {% embed 'styleguide/block' with markup %}
+              {% block heading %}Social share links - stacked{% endblock %}
+
+              {% block content %}
+                <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item flex"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+                <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item flex"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+                <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item flex"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>
+              {% endblock %}
+
+              {% block markup %}
+              <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item flex"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+              <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item flex"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+              <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item flex"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>{% endblock %}
+
+            {% endembed %}
+
+            {% embed 'styleguide/block' with markup %}
+              {% block heading %}Social share links - inline{% endblock %}
+
+              {% block content %}
+                <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+                <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+                <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>
+              {% endblock %}
+
+              {% block markup %}
+              <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item flex"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+              <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item flex"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+              <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>{% endblock %}
+
+            {% endembed %}
+
+
+        </div>
+
+        <script src="scripts/vendors.js"></script>
+        <script src="scripts/app.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
+    </body>
+</html>
+
+

--- a/src/templates/pages/styleguide.twig
+++ b/src/templates/pages/styleguide.twig
@@ -26,6 +26,7 @@
                    <li><a href="styleguide-forms.html">Form Elements</a>
                    <li><a href="styleguide-grid.html">Grid</a>
                    <li><a href="content-block-examples.html">Content block examples</a>
+                   <li><a href="styleguide-social.html">Social share buttons</a>
                 </ul>
                 {% endblock %}
             {% endembed %}


### PR DESCRIPTION
Based on https://static.moveon.org/giraffe/petition.html.
For use in Wordpress sidebar. Includes stacked and inline styles.
<img width="1187" alt="move_on_styleguide" src="https://user-images.githubusercontent.com/5560919/38267329-643da4ce-3738-11e8-9207-afb7b6215780.png">
