### PR TITLE
add share_item button styles

### DIFF
--- a/src/styles/mo-components/_buttons.scss
+++ b/src/styles/mo-components/_buttons.scss
@@ -61,28 +61,3 @@ button {
     }
   }
 }
-
-.share-btn {
-  display: inline-flex;
-  text-align: center;
-  font-size: 1.1em;
-  width: 100%;
-  align-items: center;
-  justify-content: center;
-  @include btn--azure;
-  padding: 10px 20px;
-  color: $white !important; // override `a` color
-
-  &:hover {
-    svg {
-      fill: $white;
-    }
-  }
-
-  svg {
-    margin-right: 10px;
-    fill: $white;
-    height: 18px;
-    width: 18px;
-  }
-}

--- a/src/styles/mo-components/_buttons.scss
+++ b/src/styles/mo-components/_buttons.scss
@@ -61,3 +61,28 @@ button {
     }
   }
 }
+
+.share-btn {
+  display: inline-flex;
+  text-align: center;
+  font-size: 1.1em;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  @include btn--azure;
+  padding: 10px 20px;
+  color: $white !important; // override `a` color
+
+  &:hover {
+    svg {
+      fill: $white;
+    }
+  }
+
+  svg {
+    margin-right: 10px;
+    fill: $white;
+    height: 18px;
+    width: 18px;
+  }
+}

--- a/src/styles/mo-components/_social.scss
+++ b/src/styles/mo-components/_social.scss
@@ -1,10 +1,11 @@
-.share_item, .share_item:active, .share_item:visited {
+.share_item {
   display: inline-flex;
   font-size: 1rem;
   line-height: 20px;
   padding: .5em;
   margin-right: 2em;
   color: $azure;
+
   svg {
     width: 20px;
     height: 20px;
@@ -12,8 +13,59 @@
     margin-right: 1em;
     fill: $azure;
   }
+
+  &:active,
+  &:visited {
+    color: $azure;
+
+    svg {
+      fill: $azure;
+    }
+  }
+
   &.flex {
     display: flex;
   }
-}
 
+  &__btn {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    @include btn--azure;
+    padding: 10px 20px;
+    color: $white;
+
+    &:active,
+    &:visited {
+      color: $white;
+
+      &:hover {
+        color: $white;
+
+        svg {
+          fill: $white;
+        }
+      }
+    }
+
+    &:hover {
+      color: $white;
+
+      svg {
+        fill: $white;
+      }
+    }
+
+    &.flex {
+      display: flex;
+    }
+
+    svg {
+      width: 20px;
+      height: 20px;
+      padding: 0;
+      margin-right: 1em;
+      fill: $white;
+    }
+  }
+}

--- a/src/templates/pages/styleguide-social.twig
+++ b/src/templates/pages/styleguide-social.twig
@@ -50,6 +50,38 @@
 
             {% endembed %}
 
+            {% embed 'styleguide/block' with markup %}
+              {% block heading %}Social share links - stacked buttons{% endblock %}
+
+              {% block content %}
+                <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn flex"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+                <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn flex"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+                <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item__btn flex"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>
+              {% endblock %}
+
+              {% block markup %}
+              <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn flex"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+              <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn flex"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+              <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item__btn flex"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>{% endblock %}
+
+            {% endembed %}
+
+            {% embed 'styleguide/block' with markup %}
+              {% block heading %}Social share links - inline buttons{% endblock %}
+
+              {% block content %}
+                <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+                <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+                <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item__btn"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>
+              {% endblock %}
+
+              {% block markup %}
+              <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+              <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+              <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item__btn"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>{% endblock %}
+
+            {% endembed %}
+
 
         </div>
 
@@ -58,5 +90,3 @@
         <script>hljs.initHighlightingOnLoad();</script>
     </body>
 </html>
-
-

--- a/src/templates/pages/styleguide-social.twig
+++ b/src/templates/pages/styleguide-social.twig
@@ -54,14 +54,14 @@
               {% block heading %}Social share links - stacked buttons{% endblock %}
 
               {% block content %}
-                <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn flex"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
-                <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn flex"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+                <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn flex mb-2"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+                <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn flex mb-2"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
                 <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item__btn flex"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>
               {% endblock %}
 
               {% block markup %}
-              <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn flex"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
-              <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn flex"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
+              <a href="https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Ffront.moveon.org" target="_blank" aria-label="Share on Facebook" class="share_item__btn flex mb-2"><svg><use xlink:href="#facebook"></use></svg>Share on Facebook</a>
+              <a href="https://twitter.com/intent/tweet/?via=MoveOnOrg" target="_blank" aria-label="Share on Twitter" class="share_item__btn flex mb-2"><svg><svg><use xlink:href="#twitter"></use></svg></svg>Tweet this</a>
               <a href="mailto:?subject=An%20article%20from%20MoveOn%20&amp;body=http%3A%2F%2Ffront.moveon.org" class="share_item__btn flex"><svg><svg><use xlink:href="#mail"></use></svg></svg>Email a friend</a>{% endblock %}
 
             {% endembed %}


### PR DESCRIPTION
Seems that the `&__`  doesn't inherit the parent so I had to duplicate some styles from the standard link styles.

Also the 'stacked' buttons look weird in the styleguide, but I do want that fullwidth style for use in containers (note, though you can't see it easily, the links are fullwidth as they were).