### PR TITLE
Responsive images need height:auto to preserve aspect ratio

### DIFF
--- a/src/styles/mo-components/_content.scss
+++ b/src/styles/mo-components/_content.scss
@@ -24,6 +24,7 @@ b, .bold {
 
 img {
   max-width: 100%;
+  height: auto;
 }
 
 .text-align-center {


### PR DESCRIPTION
Closes #166.