### PR TITLE
Align blockquote styling with comps

### DIFF
--- a/src/styles/components/_blockquote.scss
+++ b/src/styles/components/_blockquote.scss
@@ -1,20 +1,26 @@
 blockquote {
-  border: none;
-  padding: 0;
+  border-left: .5rem solid $ice-blue;
+  padding: .5rem 1rem;
   @include clearfix;
   @include respond((
-    margin-top: 36px null auto,
-    margin-bottom: auto,
-    margin-left: null null 100px,
+    margin-top: null,
+    margin-bottom: 1em,
+    margin-left: null,
   ));
 
   p {
-    @include font(roboto-medium);
+    color: $slate-gray;
+    @include font(roboto-regular);
     @include respond((
-      font-style: italic,
-      font-size: 16px null 24px,
-      line-height: 24px null 36px,
+      font-size: 16px,
+      line-height: 24px,
     ));
+  }
+
+  p:last-of-type {
+      @include respond((
+        margin-bottom: 0,
+      ));
   }
 
   cite {

--- a/src/styles/components/_testimonial.scss
+++ b/src/styles/components/_testimonial.scss
@@ -22,10 +22,27 @@
 
 
   &__text {
+    @include font('roboto-medium');
+    font-style: italic;
     @include respond((
       margin-top: 36px null auto,
       margin-bottom: auto,
       margin-left: null null 100px,
     ));
+
+    p {
+        color: $black;
+        @include respond((
+            font-size: 16px null 24px,
+            line-height: 24px null 36px,
+            margin-bottom: 1em,
+        ));
+    }
+
+    p:last-of-type {
+        @include respond((
+            margin-bottom: 1em,
+        ));
+    }
   }
 }


### PR DESCRIPTION
Closes #168. Includes update to home page testimonial unit to re-add styles formerly inherited from the old blockquote styling.