### PR TITLE
fixes to go with front-wordpress 81-signup-form-tweaks

### DIFF
--- a/src/scripts/components/joinForm.js
+++ b/src/scripts/components/joinForm.js
@@ -39,9 +39,7 @@ class JoinForm {
     this.$form.on('change keyup', function () {
       if (_this.$mobile[0].value.replace(/\D/g,'').length >= 10) {
         _this.$userSmsSubscribe[0].checked = true;
-        if (_this.$subscribeSMSConditions[0].className.search("unhide") == -1) {
-          _this.$subscribeSMSConditions[0].className += " unhide";
-        }
+        _this.$subscribeSMSConditions[0].classList.remove("dimmed");
       }
     });
 

--- a/src/styles/components/_join.scss
+++ b/src/styles/components/_join.scss
@@ -10,7 +10,7 @@
 
     form {
       @include respond((
-        padding: (50px 14px 60px) null (70px 24px 80px),
+        padding: (50px 14px 20px) null (70px 24px 25px),
       ))
     }
   }

--- a/src/styles/mo-components/_fixes.scss
+++ b/src/styles/mo-components/_fixes.scss
@@ -151,66 +151,6 @@ body.donate-page {
       border: none;
       background: transparent;
     }
-
-    .products-list {
-      h3 {
-        padding-bottom: 10px;
-      }
-
-      table {
-        border-collapse: collapse;
-      }
-    }
-
-    .product-header {
-      th {
-        padding: 5px 0 10px;
-      }
-    }
-
-    .amount-other {
-      position: relative;
-    }
-
-    .other-label {
-      position: absolute;
-      top: 14px;
-      left: 10px;
-    }
-
-    .product-quantity input[type="number"],
-    .amount_other_field {
-      appearance: none;
-      background: transparent;
-      height: 50px;
-      border: 1px solid rgba(0, 0, 0, .54);
-      margin-right: 20px;
-      padding: 0 8px;
-      width: 70px;
-      color: rgba(0, 0, 0, .54);
-      font-size: 16px;
-      line-height: 20px;
-    }
-
-    .amount_other_field {
-      width: 100%;
-      padding-left: 20px;
-    }
-
-    .product-quantity {
-      .checkbox-input {
-        margin: auto;
-        width: 20px;
-      }
-    }
-
-    .product-details {
-      padding: 10px 0;
-
-      .input-helper {
-        margin: 0;
-      }
-    }
   }
 
   #donation-link-onetime {
@@ -263,6 +203,11 @@ body.donate-page {
 
 /* Homepage join form fixes */
 
-.subscribe-sms-conditions.unhide {
-  display: flex !important;
+.subscribe-sms-conditions {
+  display: flex;
+  opacity: 1.0;
+}
+
+.subscribe-sms-conditions.dimmed {
+  opacity: 0.5;  
 }


### PR DESCRIPTION
Terms text appears by default but is dimmed until mobile number field contains 10 digits. See also https://github.com/MoveOnOrg/front-wordpress/pull/82