### PR TITLE
add minimal loading view to check

### DIFF
--- a/src/templates/pages/loading.twig
+++ b/src/templates/pages/loading.twig
@@ -17,11 +17,19 @@
           * It must include the logo.svg file
         -->
       <div id="root">
-        <img src="images/logo.svg" alt="MoveOn Logo" />
-        <span style="font-family:'Roboto Condensed Bold'">Loading</span>
-        <span style="font-family:'Roboto Bold">.</span>
-        <span style="font-family:'Roboto Regular'">.</span>
-        <span style="font-family:'Roboto Medium">.</span>
+        <div style="background-color: #000000; text-align: center;">
+          <img src="images/logo.svg" width="180" height="86" style="position: relative; top: 43px;" alt="MoveOn Logo" />
+        </div>
+        <div style="position: relative; top: 60px; text-align: center;">
+          <span style="font-family:'Roboto Condensed Bold'">
+            Thousands of activist bits and bytes are marching forward to build your page!
+            Just a sec
+          </span>
+          <span style="font-family:'Roboto Bold">.</span>
+          <span style="font-family:'Roboto Regular'">.</span>
+          <span style="font-family:'Roboto Medium">.</span>
+          [loading....]
+        </div>
       </div>
     </body>
 </html>

--- a/src/templates/pages/loading.twig
+++ b/src/templates/pages/loading.twig
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="giraffe">
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta charset="utf-8">
+        <title>{% block title %}Move On{% endblock %}</title>
+    </head>
+    <body>
+      <!--
+          This is not allowed to depend on any css from the css file.
+          It must only depend on inline css included in this file
+          This data should be absolutely minimal
+          For preloading:
+          * It must use all fonts used e.g. in petition sign page,
+          but should be ok to render before the font is loaded
+          * It must include the logo.svg file
+        -->
+      <div id="root">
+        <img src="images/logo.svg" alt="MoveOn Logo" />
+        <span style="font-family:'Roboto Condensed Bold'">Loading</span>
+        <span style="font-family:'Roboto Bold">.</span>
+        <span style="font-family:'Roboto Regular'">.</span>
+        <span style="font-family:'Roboto Medium">.</span>
+      </div>
+    </body>
+</html>


### PR DESCRIPTION
This is more a stub that you can edit for us to include on the petitions site.  What should render that achieves the goals of:
* force-loading fonts early (i.e. we need to have an instance of each font)
* force early-loading logo.svg (needs to include the logo)
* is as absolutely small as possible

I'd like to suggest we merge this, but then someone comp something/edit this file to use minimal inline css to render it.