### PR TITLE
Fix ie11 nav and footer

### DIFF
--- a/src/images/logo.svg
+++ b/src/images/logo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="180px" height="86px" viewBox="0 0 180 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 180 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
     <title>Page 1 Copy 9</title>
     <desc>Created with Sketch.</desc>

--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -7,7 +7,6 @@
     position: fixed null relative,
     background-color: $white null transparent,
     display: block null flex,
-    justify-content: flex-end,
     align-items: flex-end,
   ));
 


### PR DESCRIPTION
We shouldn't need flex-end in the nav since all containers have a margin to position them on the correct side.

Here's why I removed the logo size from the svg https://stackoverflow.com/questions/9777143/svg-in-img-element-proportions-not-respected-in-ie9/9792254#9792254

fixes #194 