### PR TITLE
Hide sign now button on desktop

### DIFF
--- a/src/styles/components/_sign-form.scss
+++ b/src/styles/components/_sign-form.scss
@@ -39,7 +39,9 @@
   }
 
   &__fixed-button {
-    display: block;
+    @include respond((
+      display: block none null
+    ));
     text-align: center;
     width: 100%;
     height: 50px;


### PR DESCRIPTION
part of https://github.com/MoveOnOrg/mop-frontend/issues/459