### PR TITLE
set cache-control header for production site to a year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ deploy:
     skip_cleanup: true
     region: us-east-2
     acl: public_read
+    cache_control: max-age=31536000
     local_dir: deploy
     upload-dir: giraffe
     secret_access_key:


### PR DESCRIPTION
 (we vary with a `?v=...` query string manually when we want to refresh)