### PR TITLE
Giving the titles a max-width fixes wrapping in IE

### DIFF
--- a/src/styles/components/_home-carousel.scss
+++ b/src/styles/components/_home-carousel.scss
@@ -146,6 +146,7 @@
     white-space: pre-line;
     text-align: center;
     padding: 10px;
+    max-width: 100%;
     @include respond((
       font-size: (20px !important) null (28px !important),
     ));


### PR DESCRIPTION
For #124, which I reopened because the fix we committed earlier wasn't sufficient to get the titles to wrap correctly in IE. Putting a max-width of 100% on them seems to fix it there, without any regressions I can see in FF or Chrome.