### PR TITLE
Set max-width on hero item content to force it to wrap in IE

### DIFF
--- a/src/styles/components/_home-hero.scss
+++ b/src/styles/components/_home-hero.scss
@@ -214,6 +214,7 @@
 
   &__heading {
     @include respond((
+      max-width: 100%,
       margin-right: null null nul 83px,
       line-height: 1,
     ));
@@ -240,6 +241,7 @@
     @include respond((
       font-size: 16px,
       line-height: 24px,
+      max-width: 100%
     ));
 
     strong {


### PR DESCRIPTION
This is to fix [the bug in IE where home page hero content is not wrapping](https://github.com/MoveOnOrg/front-wordpress/issues/112) to fit the width of the container.  I put the fix in the component's styling in Giraffe since that's where all the other styling for this component is.