### PR TITLE
Created minimalist front.js file and removed some unnecessary cruft from main.css and vendors js and css

### DIFF
--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -8,6 +8,7 @@ let notifier = require('node-notifier');
 let output = projectRoot('public/scripts/app.js');
 let donateOutput = projectRoot('public/scripts/donate.js');
 let actionkitOutput = projectRoot('public/scripts/giraffe-actionkit.js');
+let frontOutput = projectRoot('public/scripts/front.js');
 
 let isDev = isDevelopment || isLocal ? true : false;
 let isProd = isStaging || isProduction ? true : false;
@@ -46,6 +47,15 @@ module.exports = {
         file: actionkitOutput,
         format: 'iife',
         name: 'actionkit_scripts',
+        sourcemap: isDev ? true : false,
+      });
+
+      const frontBundle = await rollup.rollup(rollupConfig({ entry: projectRoot('src/scripts/front.js') }));
+
+      await frontBundle.write({
+        file: frontOutput,
+        format: 'iife',
+        name: 'front_scripts',
         sourcemap: isDev ? true : false,
       });
 

--- a/src/scripts/front.js
+++ b/src/scripts/front.js
@@ -1,0 +1,13 @@
+import Nav from './components/nav';
+import HomeCarousel from './components/homeCarousel';
+import HomeHero from './components/homeHero';
+import JoinForm from './components/joinForm';
+import FormsInputBlock from './components/formsInputBlock';
+
+$(document).ready(function () {
+  Nav.init();
+  HomeCarousel.init();
+  HomeHero.init();
+  JoinForm.init();
+  FormsInputBlock.init();
+});

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -69,7 +69,6 @@ body {
   @import 'components/petition-card';
   @import 'components/petition-details';
   @import 'components/donate-form';
-  @import 'components/donate-form-v1';
   @import 'components/donate-form-v3';
   @import 'components/donate-terms';
   @import 'components/donate-terms-v3';
@@ -81,7 +80,6 @@ body {
 // PAGE STYLES
 @import 'pages/petition';
 @import 'pages/donate';
-@import 'pages/donate-v1';
 @import 'pages/donate-v3';
 @import 'pages/donate-quickpay-v3';
 @import 'pages/donate-confirm';

--- a/vendors.config.js
+++ b/vendors.config.js
@@ -2,7 +2,6 @@ module.exports = {
 
   styles: [
     'node_modules/flickity/dist/flickity.min.css',
-    'bower_components/highlightjs/styles/default.css',
   ],
 
 
@@ -10,7 +9,6 @@ module.exports = {
     'node_modules/jquery/dist/jquery.min.js',
     'node_modules/flickity/dist/flickity.pkgd.min.js',
     'node_modules/flickity-sync/flickity-sync.js',
-    'bower_components/highlightjs/highlight.pack.min.js',
   ],
 
 


### PR DESCRIPTION
addresses https://github.com/MoveOnOrg/giraffe/issues/204
related https://github.com/MoveOnOrg/front-wordpress/issues/99

- [ ] Highlightjs is used only in the styleguide (just adds syntax color coding to code blocks). 
- [ ] Donate page v1 is not implemented anywhere and v2 and v3 styles do not depend on v1.