### PR TITLE
Remove eyebrow text from secondary homepage carousel 

### DIFF
--- a/src/styles/components/_home-carousel.scss
+++ b/src/styles/components/_home-carousel.scss
@@ -121,22 +121,16 @@
       &:hover {
         color: $white;
       }
-
-      h3 {
-        padding-top: 10%;
-      }
     }
   }
 
   &__title {
-    position: relative;
     @include font(roboto-bold);
     margin-bottom: auto;
-    top: -30px !important;
     line-height: 1;
     white-space: pre-line;
     text-align: center;
-    padding: 10px;
+    padding: 20px 10px;
     max-width: 100%;
     @include respond((
       font-size: (20px !important) null (23px !important),

--- a/src/styles/components/_home-carousel.scss
+++ b/src/styles/components/_home-carousel.scss
@@ -121,21 +121,12 @@
       &:hover {
         color: $white;
       }
+
+      h3 {
+        padding-top: 10%;
+      }
     }
   }
-
-
-  &__eyebrow {
-    text-transform: uppercase;
-    @include font(roboto-condensed-bold);
-    margin-top: 27px;
-    @include respond((
-      font-size: (14px !important) null (20px !important),
-      line-height: (1 !important) null (24px !important),
-      margin-bottom: 86px null 34px,
-    ));
-  }
-
 
   &__title {
     position: relative;


### PR DESCRIPTION
The "NEWS" is gone. Per https://github.com/MoveOnOrg/front-wordpress/issues/125