### PR TITLE
fix secondary carousel overage

### DIFF
--- a/src/styles/trumps/_flickity.scss
+++ b/src/styles/trumps/_flickity.scss
@@ -18,6 +18,8 @@
   }
 }
 
-.flickity-viewport {
-  overflow: visible !important;
+.home-hero__content__carousel {
+  .flickity-viewport {
+    overflow: visible !important;
+  }
 }


### PR DESCRIPTION
Fixes overflowing content in secondary carousel - there should just be three slides visible at any time. 
<img width="1217" alt="moveon__people-powered_progress___moveon_org___democracy_in_action" src="https://user-images.githubusercontent.com/5560919/39319126-64d52b70-493d-11e8-9922-09f459e5c747.png">
