### PR TITLE
Also display footer social icons on mobile

### DIFF
--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -248,11 +248,9 @@
 
 
   &__social {
-    @include respond((
-      display: none null flex,
-      align-items: center,
-      flex-shrink: 1,
-    ));
+    display: flex;
+    align-items: center;
+    flex-shrink: 1;
 
     a {
       display: flex;


### PR DESCRIPTION
They will appear below the disclaimers, we'd have to change the html in various places to change this. Which I'm happy to look into if wanted.

closes https://github.com/MoveOnOrg/mop-frontend/issues/478

<img width="373" alt="image" src="https://user-images.githubusercontent.com/872456/40181861-157f0574-59b8-11e8-82df-39783ba609b6.png">