### PR TITLE
Black color for labels and inputs

### DIFF
--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -6,7 +6,7 @@ form {
 
   .input-block {
     position: relative;
-    color: $light-gray;
+    color: $dark-gray;
     @include respond((
       font-size: 14px null 16px,
       line-height: 20px,
@@ -180,7 +180,7 @@ form {
   .checkbox-input, .radio-input {
     label {
       font-weight:inherit;
-      color: rgba(0,0,0,0.54);
+      color: $dark-gray;
       @include font(roboto);
       @include respond((
         margin-left: 10px,
@@ -190,10 +190,10 @@ form {
     }
     &.label-above {
       display:block;
-      color: $light-gray;
+      color: $dark-gray;
       font-size: .95rem;
       label {
-        color: $light-gray;
+        color: $dark-gray;
         display:block;
         margin:0 0 0.5em 0;
         position:relative;
@@ -263,7 +263,7 @@ form {
       height: 50px;
       border: 1px solid rgba(0,0,0,.54);
       padding: 0 10px;
-      color: rgba(0,0,0,.54);
+      color: $dark-gray;
       margin-left: 8px;
       @include respond((
         font-size: 16px,
@@ -342,7 +342,7 @@ form {
       height: 50px;
       border: 1px solid rgba(0,0,0,.54);
       padding: 0 10px;
-      color: rgba(0,0,0,.54);
+      color: $dark-gray;
       margin-left: 8px;
       @include respond((
         font-size: 16px,


### PR DESCRIPTION
This commit sets the color of the form labels and inputs to black ($dark-gray), I made this changes given I've been requested to make the labels and inputs black on action kit and the color is set here.

Given that this affects other sections (than action kit) that I'm not aware, please review carefully before approve :)