### PR TITLE
Fixed labels height

### DIFF
--- a/src/styles/mo-components/_errors.scss
+++ b/src/styles/mo-components/_errors.scss
@@ -17,6 +17,9 @@ form {
       color: $muted-red;
       label {
         color: $muted-red;
+        &.ak-error {
+          max-height: 9999999999px;
+        }
       }
       input,
       textarea,

--- a/src/templates/pages/styleguide-forms.twig
+++ b/src/templates/pages/styleguide-forms.twig
@@ -166,7 +166,7 @@
                         </div>
                         
                         <div class="input-block label-before-input mt-4 giraffe-has-errors m-0 mt-4 pl-0 pr-0">
-                          <label>Label - Select with empty value option and option text and with .label-before-input and .giraffe-has-errors class on the parent</label>
+                          <label class="ak-error">Label - Select with empty value option and option text and with .label-before-input and .giraffe-has-errors class on the parent. Nullam cursus dui et mattis pulvinar. Integer nec velit at nibh cursus maximus. Mauris vel quam feugiat, congue lectus luctus, rutrum sapien. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer lacinia lacinia posuere. Sed a augue vel urna rutrum luctus id vel dui. Ut dolor augue, ullamcorper eget magna nec, vulputate maximus leo. Sed interdum ut magna a vulputate. Nulla id tincidunt purus, eget dictum diam. Etiam nisl nulla, vehicula a imperdiet sit amet, convallis id tellus. Suspendisse potenti. Pellentesque lacus velit, aliquam sed eros ut, tincidunt pretium turpis. Nam feugiat egestas urna, non efficitur ligula porttitor in. Nullam luctus varius orci id dictum. Maecenas elementum quam et arcu placerat pellentesque. Nulla ac orci euismod, elementum nulla nec, finibus nunc.</label>
                           <select name="select_a" id="id_select_a"><option value="">Select one</option><option value="Y">Yes</option> <option value="N">No</option></select>
                         </div>
                         


### PR DESCRIPTION
This fixes the label height allowing to use long text on them.

you can test by checking the last field on this page: https://static.moveon.org/giraffe/styleguide-forms.html after merge or locally if you clone this branch.

Once this is merged it can be tested here: https://act.moveon.org/survey/nationalsummitconfirmation_copy 