### PR TITLE
add position:absolute to content-block for event pages 

### DIFF
--- a/src/styles/mo-components/_content-block.scss
+++ b/src/styles/mo-components/_content-block.scss
@@ -1,4 +1,5 @@
 .content-block {
+  position: relative; /* helps content inside a block to position:absolute to be in the upper-right corner, e.g. fine-print-message incontentblock for U.S. territory-only message */
   box-sizing: border-box;
   .video-wrapper {
     position: relative;


### PR DESCRIPTION
to fit US-only message inside blue boundary when there is a header above.
![usonly-eventcreate](https://user-images.githubusercontent.com/52117/51714616-babbd580-202d-11e9-973a-bbcc0d0fa807.png)
![usonly-eventattend](https://user-images.githubusercontent.com/52117/51714617-bb546c00-202d-11e9-9803-b89540a477c4.png)
