### PR TITLE
adding panther stub; page menus, breadcrumbs, and striped lists

### DIFF
--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -503,7 +503,7 @@ form {
   }
 }
 
-// variations depending parent's bg color
+/* variations depending bg color of parent */
 .bg-off-white.relative-font-color-for-bg {
   .input-block {
     color: $dark-gray;
@@ -560,5 +560,39 @@ form {
     & input[type="number"] {
       color: $light-gray;
     }
+  }
+}
+
+
+/** Panther Form style **/
+.panther {
+  input.form-control,
+  select,
+  textarea {
+    border:0;
+    border-radius:0;
+    width:100%;
+    /* from bootstrap */
+    line-height: 1.5;
+    padding: .374rem .75rem;
+    background-color: white;
+  }
+
+  /* TODO: what to do in white background?  border or bg change? */
+
+  label {
+    margin-bottom: .5rem;
+    line-height: 1.5;
+    display: inline-block;
+  }
+  .form-group {
+    margin-bottom: 1rem;
+  }
+  .btn[type="submit"] {
+    font-size: 18px;
+    background-color: $azure;
+    color: #fff;
+    padding: 5px 10px;
+    min-width: 100px;
   }
 }

--- a/src/styles/components/_headings.scss
+++ b/src/styles/components/_headings.scss
@@ -30,3 +30,43 @@ h4 {
 h5 {
   font-size: .8rem;
 }
+
+h1,h2,h3,h4,h5 {
+    /* browsers won't navigate to a display:none element
+       so we use visibility
+     */
+    & a.anchor-link {
+      visibility: hidden;
+      float: left;
+      margin-left: -20px;
+      width: 20px;
+    }
+    &:hover a.anchor-link, a.anchor-link:hover {
+      visibility: visible;
+    }
+}
+
+.anchor-link {
+  /* This is for navigation links so e.g.
+     <div class="anchor-link-section">
+       <div id="foo" class="anchor-id"></div>
+     </div>
+     and then #foo will go to where .toc-section is -- with proper offset from the header.
+     You can ALSO have a hover link like so:
+     <h2>Section Name
+       <a href="#foo" class="anchor-link">
+         <span id="foo" class="anchor-id"></span>
+         <svg width="14px" height="14px"><use xlink:href="#link"/></svg>
+       </a>
+     </h2>
+   */
+  position: relative;
+  .anchor-id {
+    margin-top: -130px;
+    position: absolute;
+
+    @media only screen and (max-width: $bp-md) {
+      margin-top: -60px;
+    }
+  }
+}

--- a/src/styles/components/_lists.scss
+++ b/src/styles/components/_lists.scss
@@ -1,3 +1,16 @@
 ul, ol {
   margin-left: .625em;
 }
+
+ul.list-striped {
+  li {
+    list-style-type: none;
+    display:block;
+    max-width: 100%;
+    word-wrap: normal;
+  }
+  li:nth-child(odd){
+    background-color: $off-white;
+  }
+
+}

--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -71,6 +71,12 @@
     ));
   }
 
+  li > span {
+    @include respond((
+      color: $black null $white
+    ));
+  }
+
   li > a {
     transition: all .3s;
     @include respond((
@@ -335,5 +341,48 @@
         display: none;
       }
     }
+  }
+}
+
+.mobile-pagemenu {
+  display:none;
+  text-align: center;
+}
+.mobile-pagemenu, .pagemenu {
+  /* TODO: specify what it should look like for desktop */
+
+  @media only screen and (max-width: $bp-md) {
+    display: block;
+    text-align: center;
+  }
+  &.force {
+    display: block
+  }
+
+  ul,
+  li {
+    margin: 0;
+    padding: 0;
+  }
+  li {
+    list-style-type: none;
+    text-transform:capitalize;
+    a {
+      color:#00abff;
+      font-weight:600;
+    }
+  }
+}
+
+.breadcrumb-link {
+  margin-top: .5rem;
+  text-align: right;
+  font-size: .85rem;
+  display: block;
+  height: 24px;
+
+  a {
+    color: $azure;
+    font-weight: 600;
   }
 }

--- a/src/templates/pages/index.twig
+++ b/src/templates/pages/index.twig
@@ -10,15 +10,15 @@
   <h2>Components</h2>
     <ul>
       <li><a href="styleguide/basics.html">Basics: Colors, Static content</a></li>
-      <li><a href="styleguide/grid.html">Grid</a></li>
+      <li><a href="styleguide/grid.html">Grid and Layout</a></li>
       <li><a href="styleguide/forms.html">Form Components</a></li>
       <li><a href="styleguide/social.html">Social links, etc</a></li>
+      <li><a href="styleguide/headers.html">Headers</a></li>
+      <li><a href="styleguide/logos.html">Logos</a></li>
     </ul>
     <h3>TODO</h3>
     <ul>
-      <li><a href="styleguide/headers.html">Headers</a></li>
       <li><a href="styleguide/forms-panther.html">Form Components (Panther)</a></li>
-      <li><a href="styleguide/logos.html">Logos</a></li>
       <li><a href="styleguide/style-integration.html">Integrating other CSS/styles</a></li>
     </ul>
 

--- a/src/templates/pages/styleguide/basics.twig
+++ b/src/templates/pages/styleguide/basics.twig
@@ -1,4 +1,4 @@
-{% set markup = { blocks: ['markup']} %}
+{% set path = '../' %}
 
 <!DOCTYPE html>
 <html>
@@ -72,7 +72,7 @@
             {% endembed %}
 
             {# BUTTONS #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' %}
                 {% block heading %}Buttons{% endblock %}
                 {% block guidance %}Using A elements is better for hyperlinks, since browsers will work in predictable ways. Use buttons for form elements.{% endblock %}
                 {% block content %}
@@ -136,7 +136,7 @@ BETTER:
 
 
             {# TYPOGRAPHY #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' %}
                 {% block heading %}Typography: Headings{% endblock %}
                 {% block content %}
                     <h1>Heading 1</h1>
@@ -144,13 +144,27 @@ BETTER:
                     <h3>Heading 3</h3>
                     <h4>Heading 4</h4>
                     <h5>Heading 5</h5>
+                    <h3>Heading with Anchor
+                      <a href="#foooooo" class="anchor-link">
+                        <span id="foooooo" class="anchor-id"></span>
+                        <svg width="14px" height="14px"><use xlink:href="#link"/></svg>
+                      </a>
+                    </h3>
                 {% endblock %}
-                {% block markup %}<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5>
+                {% block markup %}
+<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5>
+
+<h3>Heading with Anchor
+  <a href="#foooooo" class="anchor-link">
+    <span id="foooooo" class="anchor-id"></span>
+    <svg width="14px" height="14px"><use xlink:href="#link"/></svg>
+  </a>
+</h3>
                 {% endblock %}
             {% endembed %}
 
             {# TYPOGRAPHY: BODY #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' %}
                 {% block heading %}Typography: Body{% endblock %}
                 {% block content %}
                     <div class="styleguide-headings">
@@ -162,7 +176,7 @@ BETTER:
             {% endembed %}
 
             {# TYPOGRAPHY: LIST #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' %}
                 {% block heading %}Typography: List{% endblock %}
                 {% block content %}
                     <div class="styleguide-list">
@@ -182,8 +196,29 @@ BETTER:
 </ul>{% endblock %}
             {% endembed %}
 
+            {# TYPOGRAPHY: STRIPED LIST #}
+            {% embed 'styleguide/block' with {'id':'striped'} %}
+                {% block heading %}Typography: Striped List{% endblock %}
+                {% block content %}
+                    <div>
+                        <ul class="list-striped">
+                            <li class="p-2">2018 Elections</li>
+                            <li class="p-2">Tax Reform</li>
+                            <li class="p-2">Immigration</li>
+                            <li class="p-2">Healthcare</li>
+                        </ul>
+                    </div>
+                {% endblock %}
+                {% block markup %}<ul class="list-striped">
+  <li class="p-2">2018 Elections</li>
+  <li class="p-2">Tax Reform</li>
+  <li class="p-2">Immigration</li>
+  <li class="p-2">Healthcare</li>
+</ul>{% endblock %}
+            {% endembed %}
+
             {# TYPOGRAPHY: BLOCKQUOTE #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' %}
                 {% block heading %}Typography: Blockquote{% endblock %}
                 {% block content %}
                     <div class="styleguide-description">
@@ -207,7 +242,7 @@ BETTER:
             {% endembed %}
 
             {# CTA LINKS #}
-            {% embed 'styleguide/block' with markup %}
+            {% embed 'styleguide/block'  %}
                 {% block heading %}Typography: CTA Links{% endblock %}
                 {% block content %}
                     <div class="styleguide-description">
@@ -267,7 +302,7 @@ BETTER:
             {% endembed %}
 
             {# TYPOGRAPHY: ANIMATED UNDERLINE #}
-            {% embed 'styleguide/block' with markup %}
+            {% embed 'styleguide/block'  %}
                 {% block heading %}Typography: Animated Underline{% endblock %}
                 {% block content %}
                     <div class="styleguide-description">
@@ -291,7 +326,7 @@ BETTER:
             {% endembed %}
 
             {# ROUND IMAGE #}
-            {% embed 'styleguide/block' with markup %}
+            {% embed 'styleguide/block'  %}
                 {% block heading %}Round Image{% endblock %}
                 {% block content %}
                     <div class="styleguide-description">
@@ -299,19 +334,19 @@ BETTER:
                     </div>
                     <div class="styleguide-round-image">
                         <div class="round-image">
-                            <img src="images/testimonial-image.jpg" alt="">
+                            <img src="{{path}}images/testimonial-image.jpg" alt="">
                         </div>
                     </div>
                 {% endblock %}
 {% block markup %}
 <div class="round-image">
-    <img src="images/testimonial-image.jpg" alt="">
+    <img src="{{path}}images/testimonial-image.jpg" alt="">
 </div>
 {% endblock %}
             {% endembed %}
 
             {# MEDIA #}
-            {% embed 'styleguide/block' with markup %}
+            {% embed 'styleguide/block' %}
                 {% block heading %}Media{% endblock %}
                 {% block content %}
                     <div class="styleguide-media">
@@ -338,7 +373,7 @@ BETTER:
             {% endembed %}
 
             {# CARDS #}
-            {% embed 'styleguide/block' with markup %}
+            {% embed 'styleguide/block' with {'id':'cards'} %}
             {% block heading %}CARDS{% endblock %}
             {% block content %}
             <div class="row">

--- a/src/templates/pages/styleguide/grid.twig
+++ b/src/templates/pages/styleguide/grid.twig
@@ -1,5 +1,3 @@
-{% set markup = { blocks: ['markup']} %}
-
 <!DOCTYPE html>
 <html>
     <head>
@@ -15,12 +13,23 @@
         <div class="wrapper">
 
           {% include 'styleguide/header' %}
-
+          <!-- FIXME: guidance around 'top' of header content -->
           <div class="stylguide-content">
+            <div class="container">
+              <div class="row">
+                <div class="md-col-6">
+                  <h1>Grid and Layout</h1>
+                </div>
+              </div>
+            </div>
 
+            <p>TKTK: guidance around what divs/classes to embed e.g. a header in (clearly not just at the top).
+              Also about columns and how they connect to mobile (feel free to link to related bootstrap docs).
+              Also about when to purposefully use/consider using the special components listed here.
+            </p>
 
             {# Section Center columns #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' with {'id': 'centercolumns'} %}
                 {% block heading %}Center columns{% endblock %}
                 {% block content %}
                     <div class="styleguide-centered-columns">
@@ -45,12 +54,68 @@
                 {% endblock %}
             {% endembed %}
 
+            {% embed 'styleguide/block' with {'id': 'expandingtoggle'} %}
+                {% block heading %}Expanding Toggles{% endblock %}
+                {% block guidance %}{% endblock %}
+                {% block content %}
+            <h3>minimalist example</h3>
+            <div>
+              <a role="button" class="accordion-toggle collapsed" data-toggle="collapse" href="#test" aria-expanded="false" >open</a>
+              <div id="test" class="collapse" role="tabpanel" style="overflow: hidden; height: 0px">
+                <p>HAPPY </p>
+              </div>
+            </div>
+
+<!-- FULL default open example -->
+TKTK (full default open example): probably from event attendee page?
+                {% endblock %}
+                {% block markup %}
+<!-- make sure you have included this script in your template -->
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+
+<!-- minimal default collapsed -->
+<div>
+  <a role="button" class="accordion-toggle collapsed" data-toggle="collapse" href="#test" aria-expanded="false" >open</a>
+  <div id="test" class="collapse" role="tabpanel" style="overflow: hidden; height: 0px">
+    <p>HAPPY </p>
+  </div>
+</div>
+
+<!-- minimal default open -->
+<div>
+  <a role="button" class="accordion-toggle collapsed" data-toggle="collapse" href="#test" aria-expanded="true" >open</a>
+  <div id="test" class="collapse" role="tabpanel" style="overflow: hidden; ">
+    <p>HAPPY </p>
+  </div>
+</div>
+
+<!-- FULL default open example -->
+TKTK
+                {% endblock %}
+            {% endembed %}
+
+
+
+            {% embed 'styleguide/block' with {'id': 'popups'} %}
+                {% block heading %}Popups{% endblock %}
+                {% block guidance %}{% endblock %}
+                {% block content %}
+                   TKTK
+                {% endblock %}
+                {% block markup %}TKTK{% endblock %}
+            {% endembed %}
+
+
           </div>
 
         </div>
-
+        <script
+	   src="http://code.jquery.com/jquery-1.12.4.min.js"
+	   integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+	   crossorigin="anonymous"></script>
         <script src="scripts/vendors.js"></script>
         <script src="scripts/app.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
         <script>hljs.initHighlightingOnLoad();</script>
     </body>
 </html>

--- a/src/templates/pages/styleguide/headers.twig
+++ b/src/templates/pages/styleguide/headers.twig
@@ -1,8 +1,7 @@
-{% set markup = { blocks: ['markup']} %}
 {% set path = '../' %}
 
 <!DOCTYPE html>
-<html>
+<html class="giraffe">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">                <meta charset="utf-8">
@@ -11,13 +10,36 @@
         <link rel="stylesheet" href="../styles/main.css" />
         <link rel="stylesheet" href="../styles/styleguide.css" />
     </head>
-    <body class="giraffe {% block bodyclass %}styleguide {% endblock %}">
+    <body class="{% block bodyclass %}styleguide {% endblock %}">
         <div style="display:none">{% include 'components/symbol/svg/sprite.symbol.svg' %}</div>
-        <div class="wrapper">
 
           {% include 'styleguide/header' %}
 
-          <div class="stylguide-content">
+
+        <div class="container">
+          <!-- TODO: where do breadcrumbs and h1 go relative to the top? -->
+              <div class="breadcrumb-link">
+                <a href="../">← Back to Styleguide</a>
+              </div>
+              <h1>The Header and page tops</h1>
+          <div class="row">
+            <div class="col-md-12">
+              <div class="pagemenu">
+                <ul>
+                  <li><a href="#future">General header guidance</a></li>
+                  <li><a href="#pagestructure">Page Structure</a></li>
+                  <li><a href="#full">Full Header</a></li>
+                  <li><a href="#minimal">Minimal Header</a></li>
+                  <li><a href="#partners">Partner Headers (TODO)</a></li>
+                  <li><a href="#banner">Campaign Headers (TODO)</a></li>
+                  <li><a href="#breadcrumbs">Below the Header: breadcrumbs (FIXME)</a></li>
+                  <li><a href="#pagemenus">Below the Header: Page Titles and menus</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="stylguide-content">
 
             <h2 class="styleguide-block__heading">General header guidance</h2>
             <div class="styleguide-block__content">
@@ -33,10 +55,39 @@
               </ul>
             </div>
 
+            {# PAGE STRUCTURE #}
+            {% embed 'styleguide/block' with {'id': 'pagestructure'} %}
+                {% block heading %}Page Structure{% endblock %}
+                {% block guidance %}
+                   <p>There are a few structures that will give you a 'working' page.
+                     The first thing to note is that ALL style is only applied UNDER a <code>class="giraffe"</code>
+                     element.  This can be useful if you want to add e.g. the header to an otherwise differently-styled
+                     page governed by other CSS.
+                   <p>Besides that, note that there are some important pieces to make the header work
+                   <ul>
+                     <li>To add padding for the content below the nav header, you must either have class="giraffe" in the html element like: <code>&lt;html class="giraffe">.....&lt;body>....</code> OR &lt;body id="giraffe-wrapper" class="giraffe"> (or the same in a lower div)
+                     <li>Include a JS file that includes the <code>Nav</code> script component (scripts/app.js, scripts/actionkit.js, or scripts/front.js) or the mobile menu won't work
+                   </ul>
+                {% endblock %}
+                {% block markup %}
+<html class="giraffe">
+  <body>
+    ....
+  </body>
+</html>
+<!-- OR -->
+<html>
+  <body id="giraffe-wrapper" class="giraffe">
+    ...
+  </body>
+</html>
+                {% endblock %}
+            {% endembed %}
+
+
             {# FULL HEADER #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' with {'id': 'full'} %}
                 {% block heading %}Full Header{% endblock %}
-                {% block id %}id="full"{% endblock %}
                 {% block content %}
                    <div style="position: relative; margin-bottom: 50px">
                    {% include 'components/header' %}
@@ -47,9 +98,8 @@
             {% endembed %}
 
             {# MINIMAL HEADER #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' with {'id': 'minimal'} %}
                 {% block heading %}Minimal Header{% endblock %}
-                {% block id %}id="minimal"{% endblock %}
                 {% block guidance %}
                    <p>Use the minimal header when we want to avoid distraction and focus the visitor
                       on the content -- often to complete an action.
@@ -76,9 +126,8 @@
 
 
             {# PARTNER HEADER #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' with {'id': 'partners'} %}
                 {% block heading %}Partner Headers{% endblock %}
-                {% block id %}id="partners"{% endblock %}
                 {% block guidance %}
                    <p>When collaborating with partners we often need to step back with MoveOn-central
                      branding. We can still work within this style-guide, but the MoveOn logo will not
@@ -91,9 +140,8 @@
             {% endembed %}
 
             {# CAMPAIGN HEADER #}
-            {% embed 'styleguide/block' with markup%}
+            {% embed 'styleguide/block' with {'id':'banner'} %}
                 {% block heading %}Campaign Headers{% endblock %}
-                {% block id %}id="banner"{% endblock %}
                 {% block guidance %}
                    <p>Some campaigns have special banners to emphasize the work.
                      When we use these, it should generally only be on the 'landing' page
@@ -105,7 +153,67 @@
                 {% block markup %}{% endblock %}
             {% endembed %}
 
+            {# BREADCRUMBS #}
+            {% embed 'styleguide/block' with {'id':'breadcrumbs'} %}
+                {% block heading %}BreadCrumbs{% endblock %}
+                {% block guidance %}
+                     FIXME: where to put this around div.container, row and header?
+                     Breadcrumb divs are styled so they will take up vertical space
+                     regardless of whether they are filled in.  That can help javascript loading
+                     to avoid 'vertical jitter' and also help place the header below the MoveOn
+                     logo overflow below the header.
+                {% endblock %}
+                {% block content %}
+                     <div class="breadcrumb-link">
+                       <a href="../">← Back to Styleguide</a>
+                     </div>
+                {% endblock %}
+                {% block markup %}<body>...
+<!-- header here -->
+<!-- ?TKTK anything else? -->
+<div class="breadcrumb-link">
+ <a href="../">← Back to Styleguide</a>
+</div>{% endblock %}
+            {% endembed %}
 
+
+            {# CAMPAIGN HEADER #}
+            {% embed 'styleguide/block' with {'id':'pagemenus'} %}
+                {% block heading %}Page Menus{% endblock %}
+                {% block guidance %}
+
+                  <p>Especially on mobile it might be useful to show a page menu at the top of the page,
+                  so people can navigate to sub-sections of the page on mobile (and understand what's on the page).
+                  Sometimes it's even useful on desktop with a large page (for instance, this one).
+                  <p>For mobile-only (hidden on desktop), use class="mobile-pagemenu" otherwise use class="pagemenu"
+                {% endblock %}
+                {% block content %}
+                  <div class="pagemenu">
+                    <ul>
+                      <li><a href="#pagemenus">Menu Option1</a></li>
+                      <li><a href="#pagemenus">Menu Option2</a></li>
+                      <li><a href="#pagemenus">Another Option</a></li>
+                    </ul>
+                  </div>
+                {% endblock %}
+                {% block markup %}<!--MOBILE ONLY-->
+<div class="mobile-pagemenu">
+  <ul>
+    <li><a href="#pagemenus">Menu Option1</a></li>
+    <li><a href="#pagemenus">Menu Option2</a></li>
+    <li><a href="#pagemenus">Another Option</a></li>
+  </ul>
+</div>
+<!--BOTH MOBILE AND DESKTOP -->
+<div class="pagemenu">
+  <ul>
+    <li><a href="#pagemenus">Menu Option1</a></li>
+    <li><a href="#pagemenus">Menu Option2</a></li>
+    <li><a href="#pagemenus">Another Option</a></li>
+  </ul>
+</div>
+{% endblock %}
+            {% endembed %}
 
           </div>
 

--- a/src/templates/pages/styleguide/social.twig
+++ b/src/templates/pages/styleguide/social.twig
@@ -1,6 +1,3 @@
-
-{% set markup = { blocks: ['markup']} %}
-
 <!DOCTYPE html>
 <html>
     <head>
@@ -18,7 +15,7 @@
           {% include 'styleguide/header' %}
 
             {# SOCIAL SHARE LINKS #}
-            {% embed 'styleguide/block' with markup %}
+            {% embed 'styleguide/block' %}
               {% block heading %}Social share links - stacked{% endblock %}
 
               {% block content %}

--- a/src/templates/styleguide/block.twig
+++ b/src/templates/styleguide/block.twig
@@ -1,12 +1,19 @@
-<section class="styleguide-block"   {% block id %}{% endblock %}>
-  <h2 class="styleguide-block__heading">{% block heading %}{% endblock %}</h2>
+<section class="styleguide-block">
+  <h2 class="styleguide-block__heading">{% block heading %}{% endblock %}
+    {% if id %}
+      <a href="#{{ id }}" class="anchor-link">
+        <span id="{{ id }}" class="anchor-id"></span>
+        <svg width="14px" height="14px"><use xlink:href="#link"/></svg>
+      </a>
+    {% endif %}
+  </h2>
   <div class="styleguide-block__content">
     {% block guidance %}{% endblock %}
   </div>
   <div class="styleguide-block__content">
     {% block content %}{% endblock %}
   </div>
-  {% if 'markup' in blocks %}
+  {% if block('markup') %}
     <pre class="styleguide-markup"><code>{{ block('markup')|escape }}</code></pre>
   {% endif %}
 </section>


### PR DESCRIPTION
Along with examples in the styleguide, this adds features included in the Host Tools page (some preview screenshots below).

This opens up some questions that @hi0ctane will have to weigh in on the stable longterm structures:
* When and where in the HTML are breadcrumbs placed (relative to bootstrap divs like container/row/etc)?
* For panther form style going forward what should we do to form sections with white backgrounds (or should we forbid those)?
* Review anchorlink style -- hover with a link helps on content/navigation pages.  It probably needs some finesse
* Page menus: review desktop style and prescribe how it should be associated with different headers (black h1s, azure bgs, etc)
* There are also a bunch of TKTKs or TODOs in the code for placeholders of other content guidance.

![HostToolsalpha1](https://user-images.githubusercontent.com/52117/54759192-7db33000-4be5-11e9-9c04-16a698227053.png)
![HostToolsalpha1mobile](https://user-images.githubusercontent.com/52117/54759199-80ae2080-4be5-11e9-9a9c-4243aaf302b7.png)
