### PR TITLE
Hide white braintreeDataFrame bar on recurring update pages

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -83,6 +83,7 @@ body {
 @import 'pages/donate-v3';
 @import 'pages/donate-quickpay-v3';
 @import 'pages/donate-confirm';
+@import 'pages/recurring-update';
 
 // MO OVERRIDES and REGRESSION FIXES
 @import 'mo-components/fixes';

--- a/src/styles/pages/_recurring-update.scss
+++ b/src/styles/pages/_recurring-update.scss
@@ -1,0 +1,5 @@
+body.recurring_update {
+  #braintreeDataFrame {
+    display: none;
+  }
+}


### PR DESCRIPTION
Currently there is a UI issue where there's extra white space at the bottom of recurring update pages (see image below)
![image](https://user-images.githubusercontent.com/9382984/103106839-dd363f00-4606-11eb-86e8-44b3642b7101.png)

That white space is an iFrame with id="braintreeDataFrame" which gets inserted on creation of the BrainTree data-collector instance

This PR sets display of this iFrame to "none" to remove the white space.
Link for QA: https://act.moveon.org/pledge/update/update?template_set=kathy-dev_main-giraffe&css=//s3.amazonaws.com/actionkit.moveon.org/static/stylesheets/kathy-dev_main-giraffe-main.css