### PR TITLE
Get travis.yml using the same node version as the projects nvmrc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 7.10.1
+- 8.4.0
 before_script:
 - npm install -g gulp-cli
 script: gulp


### PR DESCRIPTION
Currently Travis builds have been connected but failing for a long time. I got into the build logs and found this error:
```
12.89s$ npm install -g gulp-cli
0.69s$ gulp
/home/travis/build/MoveOnOrg/giraffe/node_modules/browser-sync/node_modules/micromatch/index.js:44
    let isMatch = picomatch(String(patterns[i]), { ...options, onResult }, true);
                                                   ^^^
SyntaxError: Unexpected token ...
    at createScript (vm.js:53:10)
    at Object.runInThisContext (vm.js:95:10)
    at Module._compile (module.js:543:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/travis/build/MoveOnOrg/giraffe/node_modules/browser-sync/dist/public/stream.js:3:18)
The command "gulp" exited with 1.
cache.2
store build cache
Done. Your build exited with 1.
```

This looks to be an error with how gulp was interacting with the node version that Travis was using. I was able to repro it locally by installing that version.

My theory is that updating the `travis.yml` to use the same node version as the project uses locally should fix this problem and get Travis autodeploying giraffe for us again!