### PR TITLE
Make bold-label usable in more circumstances

### DIFF
--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -508,6 +508,9 @@ form {
     }
   }
   .input-block {
+    .bold-label {
+      font-weight: bold;
+    }
     .input-white {
       background: $white;
       border: none;
@@ -524,9 +527,6 @@ form {
         position:relative;
         width:100%;
         top:0;
-      }
-      .bold-label {
-        font-weight: bold;
       }
     }
     &.active {


### PR DESCRIPTION
Test query string: &css=https://s3.amazonaws.com/actionkit.moveon.org/static/stylesheets/sophie-dev_main.css
(Checked 
https://act.moveon.org/unsubscribe/unsubscribe/?template_set=sophie-dev&css=https://s3.amazonaws.com/actionkit.moveon.org/static/stylesheets/sophie-dev_main.css
and https://act.moveon.org/survey/print_your_petition_help?&css=https://s3.amazonaws.com/actionkit.moveon.org/static/stylesheets/sophie-dev_main.css)