### PR TITLE
Add "hidden" class for form elements

### DIFF
--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -18,7 +18,7 @@ form {
   box-shadow: none;
 
   .hidden {
-    display: none;
+    display: none !important;
   }
 
   .input-block {

--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -17,6 +17,10 @@ form {
 
   box-shadow: none;
 
+  .hidden {
+    display: none;
+  }
+
   .input-block {
     position: relative;
     color: $dark-gray;


### PR DESCRIPTION
The unsubscribe page template has code that sets the "hidden" class on a checkbox when it doesn't apply, but that CSS class currently only works on donation pages.