### PR TITLE
correct paypal error display bug

### DIFF
--- a/src/styles/pages/_donate.scss
+++ b/src/styles/pages/_donate.scss
@@ -839,6 +839,8 @@ body.donate-page.donate {
     [type="radio"]:checked + label,
     [type="radio"]:not(:checked) + label {
       position: relative;
+      padding-top: 25px;
+      padding-bottom: 25px;
       padding-left: 2.3em;
       line-height: 1.7;
       cursor: pointer;
@@ -1049,6 +1051,10 @@ body.donate-page.donate {
     .wf-icon:before {
       margin: 0;
     }
+  }
+
+  #cc-panel {
+    margin-top: 20px;
   }
 
   #custom-donate-split {


### PR DESCRIPTION
Kathy reported that when there was an error in processing a payment, a white box appeared over the paypal button.

This css update adds padding to the payment buttons to make their heights explicit, which prevents this incursion from the error box.

context: https://app.asana.com/0/153988187951298/1201088190849769