### PR TITLE
Color links black with an underline on the homepage red hero

### DIFF
--- a/src/styles/components/_home-hero.scss
+++ b/src/styles/components/_home-hero.scss
@@ -114,6 +114,18 @@
 
         background-color: $red;
 
+        a,
+        a:visited,
+        a:active {
+          color: $black;
+          text-decoration: underline;
+          font-weight: bold;
+        }
+
+        a:hover {
+          color: $white;
+        }
+
         .home-hero__heading {
 
             span {


### PR DESCRIPTION
QA'd this by manually changing front-stage's importing of styles to:
`wp_enqueue_style('giraffe', 'https://static.moveon.org/static/stylesheets/ilona-fix-links-on-red-bg.css', array(), $asset_ver);
`

I'm guessing actionkit templates don't have the `home-hero-bg-red` class in them that this change [is nested in](https://github.com/MoveOnOrg/giraffe/compare/fix-links-on-red-bg?expand=1#diff-c751824d9dd52dfca731dfbc49f907fe749858341a8ff6d3007c6134bdeaf9b0R113) but I still feel a little nervous. Any other tips on checking and qa-ing here?