### PR TITLE
Help text on quickpay pages had low contrast

### DIFF
--- a/src/styles/pages/_donate_quickpay.scss
+++ b/src/styles/pages/_donate_quickpay.scss
@@ -7,6 +7,11 @@ body.donate-page {
     width: 73%;
   }
 
+  .faded-quickpay,
+  .help-block-quickpay {
+    color: #000000;
+  }
+
   #act-form-container.quickpay-form {
     background-color: #CAF4FF;
     color: $black;


### PR DESCRIPTION
Added class so that help text on quickpay pages has higher contrast for accessibility. Color selected by Bri.

See this Asana: https://app.asana.com/0/1122875596588633/1201149336619114