### PR TITLE
added option for white background vs blue background

### DIFF
--- a/src/styles/pages/_donate.scss
+++ b/src/styles/pages/_donate.scss
@@ -183,6 +183,17 @@ body.donate-page {
         display: inline;
       }
     }
+
+    .ask-text-small-white {
+      background: $white;
+      font-size: 0.5em;
+      font-weight: 400;
+
+      a {
+        color: $black;
+        display: inline;
+      }
+    }
   }
 
   h1.ask-text {


### PR DESCRIPTION
There was a request for more styles options on the ask sub-text. I've added two classes that do this; one that basically just makes the text smaller and controls links so that they don't blend into the background, and one that makes black text with a white background.