### PR TITLE
Move mixin comments so they don't appear in final file

### DIFF
--- a/src/styles/mixins/_breakpoint.scss
+++ b/src/styles/mixins/_breakpoint.scss
@@ -1,27 +1,26 @@
-/*
-IMPROVED BREAKPOINT MIXINS
-USAGE:
-1. Define your breakpoints:
-    @include define-breakpoints((
-      small: null,
-      medium: 768,
-      large: 1280 1920,
-      // $name: $sizes
-    ));
-    - $name:    A breakpoint name
-    - $sizes:   (number) The min-width. Max-width value will be computed as next breakpoint - 1.
-                (list) Min-width and max-width.
-2. Use a breakpoint:
-    @include breakpoint(medium only) {
-      // Styles here
-    }
-    - parameters: $name $scope
-        $name - One of the defined breakpoints
-        $scope (optional)
-            - only - Uses min-width and max-width
-            - down - Uses max-width only
-    - If both min-width and max-width computed values are null, no media query will be used.
- */
+// IMPROVED BREAKPOINT MIXINS
+// USAGE:
+// 1. Define your breakpoints:
+//     @include define-breakpoints((
+//       small: null,
+//       medium: 768,
+//       large: 1280 1920,
+//       // $name: $sizes
+//     ));
+//     - $name:    A breakpoint name
+//     - $sizes:   (number) The min-width. Max-width value will be computed as next breakpoint - 1.
+//                 (list) Min-width and max-width.
+// 2. Use a breakpoint:
+//     @include breakpoint(medium only) {
+//       // Styles here
+//     }
+//     - parameters: $name $scope
+//         $name - One of the defined breakpoints
+//         $scope (optional)
+//             - only - Uses min-width and max-width
+//             - down - Uses max-width only
+//     - If both min-width and max-width computed values are null, no media query will be used.
+
 
 @mixin define-breakpoints($breakpoints-map: ()) {
   @if type-of($breakpoints-map) == map {

--- a/src/styles/mixins/_respond.scss
+++ b/src/styles/mixins/_respond.scss
@@ -1,27 +1,27 @@
-/*
-  RESPOND MIXIN
-  Declare your property styles for multiple breakpoints in one line.
-  CONFIG
-  Within the mixin, assign your breakpoint names list to the $breakpoints variable.
-  USAGE:
-  An example showing different possible rules-set formats:
-  .selector {
-    @include respond((
-      display: inline-block block flex,
-      position: relative null absolute,
-      margin-top: 60px,
-      box-shadow: ( inset 0 0 10px blue,   inset 10px 10px 10px green,   none )
-      // $property: $rules-set
-    ));
-  }
-  - Params:
-    $property   - Any valid css property
-    $rules-set  - (list)  a list of properties for each breakpoint.
-                          If a list item is null, it will skip the rule for that corresponding breakpoint
-                - (single value) rule for the first breakpoint, or base.
- */
 $_breakpoints-names: map-get-key($breakpoints);
 @mixin respond( $styles-map ) {
+  /*
+    RESPOND MIXIN
+    Declare your property styles for multiple breakpoints in one line.
+    CONFIG
+    Within the mixin, assign your breakpoint names list to the $breakpoints variable.
+    USAGE:
+    An example showing different possible rules-set formats:
+    .selector {
+      @include respond((
+        display: inline-block block flex,
+        position: relative null absolute,
+        margin-top: 60px,
+        box-shadow: ( inset 0 0 10px blue,   inset 10px 10px 10px green,   none )
+        // $property: $rules-set
+      ));
+    }
+    - Params:
+      $property   - Any valid css property
+      $rules-set  - (list)  a list of properties for each breakpoint.
+                            If a list item is null, it will skip the rule for that corresponding breakpoint
+                  - (single value) rule for the first breakpoint, or base.
+   */
   @if not (type-of($styles-map) == map) { @error "$styles-map needs to be a map of properties and rules."; }
   $breakpoints: $_breakpoints-names;
   @for $i from 1 through length($breakpoints) {


### PR DESCRIPTION
For some reason, the mixin comments were appearing in the font URL for loading custom fonts.  I'm not sure of the root cause but by moving the comments we can fix the font loads.  Found this issue while trying to debug why Roboto Condensed wasn't changing font weight properly.