### PR TITLE
Fix incorrect logic

### DIFF
--- a/src/styles/settings/_typography.scss
+++ b/src/styles/settings/_typography.scss
@@ -17,7 +17,7 @@ $weights: (
 );
 
 @mixin font( $name) {
-  @if ( map-has-key($fonts, $name) & map-has-key($weights, $name)) {
+  @if ( map-has-key($fonts, $name) and map-has-key($weights, $name)) {
     font-family: map-get($fonts, $name);
     font-weight: map-get($weights, $name);
   }

--- a/src/styles/settings/_typography.scss
+++ b/src/styles/settings/_typography.scss
@@ -17,7 +17,7 @@ $weights: (
 );
 
 @mixin font( $name) {
-  @if ( map-has-key($fonts, $name) && map-has-key($weights, $name)) {
+  @if ( map-has-key($fonts, $name) & map-has-key($weights, $name)) {
     font-family: map-get($fonts, $name);
     font-weight: map-get($weights, $name);
   }


### PR DESCRIPTION
From gulp:
WARNING on line 20, column 36 of /Users/sophiewaldman/Documents/GitHub/giraffe/src/styles/settings/_typography.scss:
In Sass, "&&" means two copies of the parent selector. You probably want to use "and" instead
(It's even possible this was the root cause of the comments issue.)