### PR TITLE
LTE Fixes

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -75,6 +75,7 @@ body {
   @import "components/join";
   @import "components/petition-card";
   @import "components/petition-details";
+  @import "mo-components/hero-title";
 }
 // PAGE STYLES
 @import "pages/petition";

--- a/src/styles/mo-components/_hero-title.scss
+++ b/src/styles/mo-components/_hero-title.scss
@@ -1,0 +1,34 @@
+.hero-title {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 10%;
+  width: 100%;
+  background-color: $azure;
+  transition: background-color .3s;
+  text-align: center;
+
+  h1 {
+    display: inline-block;
+    margin-bottom: -10px;
+    text-transform: uppercase;
+    color: $azure;
+
+    // https://stackoverflow.com/a/34660112
+    span {
+      background-color: $black;
+      padding: 0 20px;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
+    }
+  }
+
+  @media (max-width: 576px) {
+    margin-bottom: -30px;
+    padding: 40px 5%;
+
+    h1 {
+      font-size: 2rem;
+    }
+  }
+}

--- a/src/styles/pages/_lte.scss
+++ b/src/styles/pages/_lte.scss
@@ -1,4 +1,6 @@
 body.lte {
+  overflow-x: hidden;
+
   a {
     cursor: pointer;
   }
@@ -9,15 +11,11 @@ body.lte {
 
   .lte-title {
     display: flex;
-    position: relative;
-    left: 50%;
-    right: 50%;
-    margin-left: -50vw;
-    margin-right: -50vw;
-    width: 100vw;
-    height: 130px;
     justify-content: center;
     align-items: center;
+    width: 200%;
+    margin: 0 -25%;
+    padding: 40px 25%;
     background-color: $azure;
     transition: background-color .3s;
     text-align: center;
@@ -36,10 +34,19 @@ body.lte {
         box-decoration-break: clone;
       }
     }
+
+    @media (max-width: 576px) {
+      margin-bottom: -30px;
+      padding: 40px 30%;
+
+      h1 {
+        font-size: 2rem;
+      }
+    }
   }
 
   .ak-form {
-    margin-top: 160px;
+    margin-top: 50px;
     min-height: 600px;
   }
 
@@ -101,7 +108,7 @@ body.lte {
   .input-white input,
   select.input-white,
   textarea {
-    height: 40px;
+    min-height: 40px;
 
     &:focus,
     &:invalid:focus {

--- a/src/styles/pages/_lte.scss
+++ b/src/styles/pages/_lte.scss
@@ -1,48 +1,10 @@
 body.lte {
-  overflow-x: hidden;
-
   a {
     cursor: pointer;
   }
 
   .hidden {
     display: none;
-  }
-
-  .lte-title {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 200%;
-    margin: 0 -25%;
-    padding: 40px 25%;
-    background-color: $azure;
-    transition: background-color .3s;
-    text-align: center;
-
-    h1 {
-      display: inline-block;
-      margin-bottom: -10px;
-      text-transform: uppercase;
-      color: $azure;
-
-      // https://stackoverflow.com/a/34660112
-      span {
-        background-color: $black;
-        padding: 0 20px;
-        -webkit-box-decoration-break: clone;
-        box-decoration-break: clone;
-      }
-    }
-
-    @media (max-width: 576px) {
-      margin-bottom: -30px;
-      padding: 40px 30%;
-
-      h1 {
-        font-size: 2rem;
-      }
-    }
   }
 
   .ak-form {


### PR DESCRIPTION
The new styled hero title was tricky to expand beyond the parent element, and had a static height set which did not accommodate longer titles, and was pretty broken on mobile. This fixes that.

Also, the title font size was a bit too big on mobile, and the content needed to be pulled up a bit under the title.

See https://act.moveon.org/lte/write-letter-test_QA_PAGE