### PR TITLE
Remove special padding for survey and unsubscribe thank-you pages

### DIFF
--- a/src/styles/pages/_survey_thanks.scss
+++ b/src/styles/pages/_survey_thanks.scss
@@ -1,8 +1,4 @@
 body.survey-pagetype.thanks-page {
-  padding-top: 75px;
-  @media screen and (min-width: $bp-lg) {
-    padding-top: 150px;
-  }
 
   ol {
     list-style: none;

--- a/src/styles/pages/_unsubscribe_thanks.scss
+++ b/src/styles/pages/_unsubscribe_thanks.scss
@@ -1,6 +1,0 @@
-body.unsubscribe-pagetype.thanks-page {
-  padding-top: 75px;
-  @media screen and (min-width: $bp-lg) {
-    padding-top: 150px;
-  }
-}


### PR DESCRIPTION
The custom padding values don't work with the current header, such that on mobile the top of the thank-you header is cut off.
Test with template set main-giraffe_cpa, e.g. https://act.moveon.org/cms/thanks/delete-your-data?template_set=main-giraffe_cpa