### PR TITLE
Update unsub thank-you styling

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -86,6 +86,7 @@ body {
 @import "pages/lte";
 @import "pages/recurring-update";
 @import "pages/survey_thanks";
+@import "pages/unsubscribe_thanks";
 @import 'pages/user_view';
 @import "mo-components/fixes";
 @import "trumps/flickity";

--- a/src/styles/pages/_unsubscribe_thanks.scss
+++ b/src/styles/pages/_unsubscribe_thanks.scss
@@ -1,5 +1,10 @@
 body.unsubscribe-pagetype.thanks-page {
-  #unsub-thanks-text p {
-    font-size:18px;
+  #unsub-thanks-text {
+    text-align:center;
+    margin-top:100px;
+    margin-bottom:100px;
+    p {
+      font-size:18px;
+    }
   }
 }

--- a/src/styles/pages/_unsubscribe_thanks.scss
+++ b/src/styles/pages/_unsubscribe_thanks.scss
@@ -1,0 +1,5 @@
+body.unsubscribe-pagetype.thanks-page {
+  #unsub-thanks-text p {
+    font-size:18px;
+  }
+}


### PR DESCRIPTION
Increase the font size slightly for unsub thank-you content.
Thank you pages:

Once-weekly
https://act.moveon.org/cms/thanks/unsubscribe_giraffe?action_id=682621759&akid=.43089745.fU6dXg&ar=1&rd=1&template_set=main-giraffe_unsub

3x-weekly
https://act.moveon.org/cms/thanks/unsubscribe_giraffe?action_id=682621559&akid=.43089745.fU6dXg&ar=1&rd=1&template_set=main-giraffe_unsub

Complete unsub:
https://act.moveon.org/cms/thanks/unsubscribe_giraffe?action_id=682622296&akid=.43089745.fU6dXg&ar=1&rd=1&template_set=main-giraffe_unsub