### PR TITLE
Update footer styles

### DIFF
--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -578,7 +578,7 @@
     svg {
       height: 30px;
       width: 30px;
-      padding: 5px;
+      padding: 6px;
       fill: #FFFFFF;
       vertical-align: bottom;
       transition: fill .3s;

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -568,7 +568,7 @@
       margin-top: 20px;
       margin-left: auto;
       margin-right: auto;
-      width: 150px;
+      width: 185px;
     }
 
     a {
@@ -578,7 +578,7 @@
     svg {
       height: 30px;
       width: 30px;
-      padding: 6px;
+      padding: 5px;
       fill: #FFFFFF;
       vertical-align: bottom;
       transition: fill .3s;


### PR DESCRIPTION
Companion to [this pull request in front-wordpress](https://github.com/MoveOnOrg/front-wordpress/pull/258).

Increases the width of the social links container in the footer, so that all links can fit on a single row. Also decreases the padding on each icon by 1 px because that seems to better match the size of the social icons in the footer on the new Elementor-built footer.
